### PR TITLE
(SIMP-549) Fix modprobe ordering for nfs_callback

### DIFF
--- a/build/pupmod-nfs.spec
+++ b/build/pupmod-nfs.spec
@@ -1,7 +1,7 @@
 Summary: NFS Puppet Module
 Name: pupmod-nfs
 Version: 4.1.0
-Release: 12
+Release: 13
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -62,6 +62,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 02 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-13
+- Updated the dependency chain for the NFS client kernel module load ordering.
+
 * Thu Feb 19 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-12
 - Migrated to the new 'simp' environment.
 

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -22,5 +22,6 @@ describe 'nfs::client' do
     it { should create_iptables__add_tcp_stateful_listen('nfs4_callback_port_testnode.example.domain') }
     it { should create_sysctl__value('fs.nfs.nfs_callback_tcpport') }
     it { should create_file('/etc/modprobe.d/nfs.conf').with_content(/options nfs callback_tcpport=876/) }
+    it { should create_exec('modprobe_nfs').that_requires('File[/etc/modprobe.d/nfs.conf]') }
   end
 end


### PR DESCRIPTION
* The exec that enabled the nfs kernel module was not guaranteed to fire
  off *after* the proper settings had been made to the
  nfs_callback_tcpport option in modprobe.d.

* Simplified the detection of the NFS kernel module being loaded for
  firing off the modprobe exec.

SIMP-549 #close