### PR TITLE
(SIMP-398) Eliminate all uses of lsb* facts

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,52 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-nfs.spec
+++ b/build/pupmod-nfs.spec
@@ -8,7 +8,6 @@ Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-augeasproviders_sysctl
 Requires: pupmod-autofs >= 4.1.0
-Requires: pupmod-common >= 4.1.0-6
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-simpcat >= 4.0.0-0
 Requires: pupmod-stunnel >= 4.2.0-0

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -34,7 +34,14 @@ class nfs::client (
   $callback_port = '876',
   $use_stunnel = ''
 ) {
+
+  validate_port($callback_port)
+  if !empty($use_stunnel) { validate_bool($use_stunnel) }
+
   include 'nfs'
+  if (!empty($use_stunnel) and $use_stunnel) or (!host_is_me($nfs_server) and $nfs::use_stunnel) {
+    include 'nfs::client::stunnel'
+  }
 
   iptables::add_tcp_stateful_listen { "nfs4_callback_port_${nfs_server}":
     client_nets => $nfs_server,
@@ -61,11 +68,4 @@ class nfs::client (
     mode    => '0640',
     content => "options nfs callback_tcpport=${callback_port}\n"
   }
-
-  if (!empty($use_stunnel) and $use_stunnel) or (!host_is_me($nfs_server) and $nfs::use_stunnel) {
-    include 'nfs::client::stunnel'
-  }
-
-  validate_port($callback_port)
-  if !empty($use_stunnel) { validate_bool($use_stunnel) }
 }

--- a/manifests/client/stunnel.pp
+++ b/manifests/client/stunnel.pp
@@ -39,6 +39,16 @@ class nfs::client::stunnel(
 ) {
   include 'nfs::client'
 
+  validate_integer($version)
+  validate_port($nfs_accept_port)
+  validate_port($nfs_connect_port)
+  validate_port($portmapper_accept_port)
+  validate_port($portmapper_connect_port)
+  validate_port($rquotad_connect_port)
+  validate_port($lockd_connect_port)
+  validate_port($mountd_connect_port)
+  validate_port($statd_connect_port)
+
   # Don't do this if you're running on yourself because, well, it's bad!
   if ! (host_is_me($nfs::nfs_server) or $nfs::is_server){
     include 'stunnel'
@@ -77,14 +87,4 @@ class nfs::client::stunnel(
       }
     }
   }
-
-  validate_integer($version)
-  validate_port($nfs_accept_port)
-  validate_port($nfs_connect_port)
-  validate_port($portmapper_accept_port)
-  validate_port($portmapper_connect_port)
-  validate_port($rquotad_connect_port)
-  validate_port($lockd_connect_port)
-  validate_port($mountd_connect_port)
-  validate_port($statd_connect_port)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,24 @@ class nfs (
 
   include 'nfs::service_names'
 
+  validate_absolute_path($rquotad)
+  validate_bool($use_stunnel)
+  validate_bool($is_server)
+  validate_bool($is_client)
+  validate_bool($nfsv3)
+  validate_bool($mountd_nfs_v1)
+  validate_bool($mountd_nfs_v2)
+  validate_bool($mountd_nfs_v3)
+  validate_bool($secure_nfs)
+  validate_integer($rpcnfsdcount)
+  validate_integer($nfsd_v4_grace)
+  validate_port($rquotad_port)
+  validate_port($lockd_tcpport)
+  validate_port($lockd_udpport)
+  validate_port($mountd_port)
+  validate_port($statd_port)
+  validate_port($statd_outgoing_port)
+
   if $use_stunnel {
     include 'stunnel'
   }
@@ -224,22 +242,4 @@ class nfs (
   if $is_client {
     include 'nfs::client'
   }
-
-  validate_absolute_path($rquotad)
-  validate_bool($use_stunnel)
-  validate_bool($is_server)
-  validate_bool($is_client)
-  validate_bool($nfsv3)
-  validate_bool($mountd_nfs_v1)
-  validate_bool($mountd_nfs_v2)
-  validate_bool($mountd_nfs_v3)
-  validate_bool($secure_nfs)
-  validate_integer($rpcnfsdcount)
-  validate_integer($nfsd_v4_grace)
-  validate_port($rquotad_port)
-  validate_port($lockd_tcpport)
-  validate_port($lockd_udpport)
-  validate_port($mountd_port)
-  validate_port($statd_port)
-  validate_port($statd_outgoing_port)
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -105,6 +105,10 @@ class nfs::server (
   include 'nfs'
   include 'tcpwrappers'
 
+  validate_net_list($client_ips)
+  validate_integer($sunrpc_udp_slot_table_entries)
+  validate_integer($sunrpc_tcp_slot_table_entries)
+
   concat_build { 'nfs':
     order => '*.export'
   }
@@ -226,8 +230,4 @@ class nfs::server (
     # isn't working correctly.
     tcpwrappers::allow { 'nfs': pattern => 'ALL' }
   }
-
-  validate_net_list($client_ips)
-  validate_integer($sunrpc_udp_slot_table_entries)
-  validate_integer($sunrpc_tcp_slot_table_entries)
 }

--- a/manifests/server/create_home_dirs.pp
+++ b/manifests/server/create_home_dirs.pp
@@ -68,6 +68,14 @@ class nfs::server::create_home_dirs (
   $syslog_facility = 'LOG_LOCAL6',
   $syslog_priority = 'LOG_NOTICE',
 ) {
+
+  validate_absolute_path($export_dir)
+  validate_absolute_path($skel_dir)
+  validate_array_member($ldap_scope, ['one','sub','base'])
+  validate_port($port)
+  validate_bool($tls)
+  validate_bool($quiet)
+
   file { '/etc/cron.hourly/create_home_directories.rb':
     owner   => 'root',
     group   => 'root',
@@ -80,11 +88,4 @@ class nfs::server::create_home_dirs (
   exec { '/etc/cron.hourly/create_home_directories.rb':
     refreshonly => true,
   }
-
-  validate_absolute_path($export_dir)
-  validate_absolute_path($skel_dir)
-  validate_array_member($ldap_scope, ['one','sub','base'])
-  validate_port($port)
-  validate_bool($tls)
-  validate_bool($quiet)
 }

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -72,12 +72,6 @@ define nfs::server::export (
 ) {
   include 'nfs::server'
 
-  $lname = inline_template('<%= @name.gsub("/","|") -%>')
-
-  concat_fragment { "nfs+$lname.export":
-    content => template('nfs/export.erb')
-  }
-
   validate_bool($insecure)
   validate_bool($rw)
   validate_bool($async)
@@ -89,4 +83,10 @@ define nfs::server::export (
   validate_bool($no_acl)
   validate_bool($no_root_squash)
   validate_bool($all_squash)
+
+  $lname = inline_template('<%= @name.gsub("/","|") -%>')
+
+  concat_fragment { "nfs+${lname}.export":
+    content => template('nfs/export.erb')
+  }
 }

--- a/manifests/server/stunnel.pp
+++ b/manifests/server/stunnel.pp
@@ -49,6 +49,13 @@ class nfs::server::stunnel (
 ) {
   include '::nfs::server'
 
+  validate_port($nfs_accept_port)
+  validate_port($portmapper_accept_port)
+  validate_port($rquotad_accept_port)
+  validate_port($nlockmgr_accept_port)
+  validate_port($mountd_accept_port)
+  validate_port($status_accept_port)
+
   Service['nfs'] -> Service['stunnel']
 
   if $version == '4' {
@@ -108,11 +115,4 @@ class nfs::server::stunnel (
       $status_accept_port
     ]
   }
-
-  validate_port($nfs_accept_port)
-  validate_port($portmapper_accept_port)
-  validate_port($rquotad_accept_port)
-  validate_port($nlockmgr_accept_port)
-  validate_port($mountd_accept_port)
-  validate_port($status_accept_port)
 }

--- a/manifests/service_names.pp
+++ b/manifests/service_names.pp
@@ -1,3 +1,7 @@
+# == Class: nfs::service_names
+#
+# This class provides appropriate service names based on the operating system.
+#
 class nfs::service_names {
   if $::operatingsystem in ['RedHat', 'CentOS'] {
     $rpcbind   = 'rpcbind'

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,53 @@
+{
+  "name":    "simp-nfs",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "manages NFS server and client, also PKI and stunnelling",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-nfs",
+  "project_page": "https://github.com/simp/pupmod-simp-nfs",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "nfs", "nfs4", "pki" ],
+  "dependencies": [
+    {
+      "name": "simp-autofs",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_sysctl",
+      "version_requirement": ">= 2.0.2"
+    },
+    {
+      "name": "simp-simpcat",
+      "version_requirement": ">= 3.4.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "simp-stunnel",
+      "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "simp-sysctl",
+      "version_requirement": ">= 4.1.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/client/stunnel_spec.rb
+++ b/spec/classes/client/stunnel_spec.rb
@@ -7,17 +7,17 @@ describe 'nfs::client::stunnel' do
     :hardwaremodel => 'x86_64',
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
-    :lsbmajdistrelease => '6',
+    :operatingsystemmajrelease => '6',
     :operatingsystem => 'RedHat',
     :operatingsystemmajrelease => '6',
     :processorcount => 4,
     :uid_min => '500'
   }}
 
-  it { should create_class('nfs::client::stunnel') }
+  it { is_expected.to create_class('nfs::client::stunnel') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_stunnel__add('nfs_client') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_stunnel__add('nfs_client') }
   end
 end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -7,21 +7,21 @@ describe 'nfs::client' do
     :hardwaremodel => 'x86_64',
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
-    :lsbmajdistrelease => '6',
+    :operatingsystemmajrelease => '6',
     :operatingsystem => 'RedHat',
     :operatingsystemmajrelease => '6',
     :processorcount => 4,
     :uid_min => '500'
   }}
 
-  it { should create_class('nfs::client') }
+  it { is_expected.to create_class('nfs::client') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should contain_class('nfs') }
-    it { should create_iptables__add_tcp_stateful_listen('nfs4_callback_port_testnode.example.domain') }
-    it { should create_sysctl__value('fs.nfs.nfs_callback_tcpport') }
-    it { should create_file('/etc/modprobe.d/nfs.conf').with_content(/options nfs callback_tcpport=876/) }
-    it { should create_exec('modprobe_nfs').that_requires('File[/etc/modprobe.d/nfs.conf]') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('nfs') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('nfs4_callback_port_testnode.example.domain') }
+    it { is_expected.to create_sysctl__value('fs.nfs.nfs_callback_tcpport') }
+    it { is_expected.to create_file('/etc/modprobe.d/nfs.conf').with_content(/options nfs callback_tcpport=876/) }
+    it { is_expected.to create_exec('modprobe_nfs').that_requires('File[/etc/modprobe.d/nfs.conf]') }
   end
 end

--- a/spec/classes/idmapd_spec.rb
+++ b/spec/classes/idmapd_spec.rb
@@ -8,18 +8,18 @@ describe 'nfs::idmapd' do
     :hardwaremodel => 'x86_64',
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
-    :lsbmajdistrelease => '6',
+    :operatingsystemmajrelease => '6',
     :operatingsystem => 'RedHat',
     :operatingsystemmajrelease => '6',
     :processorcount => 4,
     :uid_min => '500'
   }}
 
-  it { should create_class('nfs::idmapd') }
+  it { is_expected.to create_class('nfs::idmapd') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_file('/etc/idmapd.conf').with({
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_file('/etc/idmapd.conf').with({
         :content => /Domain\s=\sexample\.domain/,
         :notify  => 'Service[rpcidmapd]'
       })

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,7 @@ describe 'nfs' do
       :hardwaremodel => 'x86_64',
       :interfaces => 'lo',
       :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '6',
+      :operatingsystemmajrelease => '6',
       :operatingsystem => 'RedHat',
       :operatingsystemmajrelease => '6',
       :processorcount => 4,
@@ -20,7 +20,7 @@ describe 'nfs' do
       :hardwaremodel => 'x86_64',
       :interfaces => 'lo',
       :ipaddress_lo => '127.0.0.1',
-      :lsbmajdistrelease => '7',
+      :operatingsystemmajrelease => '7',
       :operatingsystem => 'RedHat',
       :operatingsystemmajrelease => '7',
       :processorcount => 4,
@@ -29,38 +29,38 @@ describe 'nfs' do
   }
 
   shared_examples_for "a fact set" do
-    it { should create_class('nfs') }
-    it { should compile.with_all_deps }
-    it { should create_file('/etc/exports') }
-    it { should contain_package('nfs-utils').with_ensure('latest') }
-    it { should contain_package('nfs4-acl-tools').with_ensure('latest') }
-    it { should contain_service('nfslock').with({
+    it { is_expected.to create_class('nfs') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_file('/etc/exports') }
+    it { is_expected.to contain_package('nfs-utils').with_ensure('latest') }
+    it { is_expected.to contain_package('nfs4-acl-tools').with_ensure('latest') }
+    it { is_expected.to contain_service('nfslock').with({
         :ensure  => 'running',
         :require => ['Service[rpcbind]', 'Package[nfs-utils]']
       })
     }
-    it { should contain_service('rpcbind').with({
+    it { is_expected.to contain_service('rpcbind').with({
         :ensure  => 'running',
         :require => 'Service[rpcidmapd]'
       })
     }
-    it { should contain_service('rpcidmapd').with({
+    it { is_expected.to contain_service('rpcidmapd').with({
         :ensure  => 'running',
         :require => 'Package[nfs-utils]'
       })
     }
-    it { should contain_service('rpcgssd').with({
+    it { is_expected.to contain_service('rpcgssd').with({
         :ensure  => 'running',
         :require => 'Service[rpcbind]'
       })
     }
-    it { should contain_class('nfs::client') }
+    it { is_expected.to contain_class('nfs::client') }
   end
 
   describe "RHEL 6" do
     it_behaves_like "a fact set"
     let(:facts) {base_facts['RHEL 6']}
-    it { should create_file('/etc/sysconfig/nfs').with({
+    it { is_expected.to create_file('/etc/sysconfig/nfs').with({
         :content => /MOUNTD_PORT=20048/,
     #    :notify  => ['Service[rpcidmapd]', 'Service[nfs]']
       })
@@ -69,6 +69,6 @@ describe 'nfs' do
 
   describe "RHEL 7" do
     let(:facts) {base_facts['RHEL 7']}
-    it { should create_file('/etc/sysconfig/nfs') }
+    it { is_expected.to create_file('/etc/sysconfig/nfs') }
   end
 end

--- a/spec/classes/server/create_home_dirs_spec.rb
+++ b/spec/classes/server/create_home_dirs_spec.rb
@@ -12,13 +12,13 @@ describe 'nfs::server::create_home_dirs' do
     :hardwaremodel => 'x86_64',
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
-    :lsbmajdistrelease => '6',
+    :operatingsystemmajrelease => '6',
     :operatingsystem => 'RedHat',
     :operatingsystemmajrelease => '6',
     :processorcount => 4,
     :uid_min => '500'
   }}
 
-  it { should create_class('nfs::server::create_home_dirs') }
-  it { should create_file('/etc/cron.hourly/create_home_directories.rb') }
+  it { is_expected.to create_class('nfs::server::create_home_dirs') }
+  it { is_expected.to create_file('/etc/cron.hourly/create_home_directories.rb') }
 end

--- a/spec/classes/server/stunnel_spec.rb
+++ b/spec/classes/server/stunnel_spec.rb
@@ -7,18 +7,18 @@ describe 'nfs::server::stunnel' do
     :hardwaremodel => 'x86_64',
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
-    :lsbmajdistrelease => '6',
+    :operatingsystemmajrelease => '6',
     :operatingsystem => 'RedHat',
     :operatingsystemmajrelease => '6',
     :processorcount => 4,
     :uid_min => '500'
   }}
 
-  it { should create_class('nfs::server::stunnel') }
+  it { is_expected.to create_class('nfs::server::stunnel') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should contain_class('nfs::server') }
-    it { should create_stunnel__add('nfs') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('nfs::server') }
+    it { is_expected.to create_stunnel__add('nfs') }
   end
 end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -7,36 +7,36 @@ describe 'nfs::server' do
     :hardwaremodel => 'x86_64',
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
-    :lsbmajdistrelease => '6',
+    :operatingsystemmajrelease => '6',
     :operatingsystem => 'RedHat',
     :operatingsystemmajrelease => '6',
     :processorcount => 4,
     :uid_min => '500'
   }}
 
-  it { should create_class('nfs::server') }
+  it { is_expected.to create_class('nfs::server') }
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should contain_class('nfs') }
-    it { should contain_class('tcpwrappers') }
-    it { should create_concat_build('nfs').with_order('*.export') }
-    it { should create_exec('nfs_re-export').with({
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('nfs') }
+    it { is_expected.to contain_class('tcpwrappers') }
+    it { is_expected.to create_concat_build('nfs').with_order('*.export') }
+    it { is_expected.to create_exec('nfs_re-export').with({
         :command     => '/usr/sbin/exportfs -ra',
         :refreshonly => true,
         :require     => 'Package[nfs-utils]'
       })
     }
-    it { should contain_service('nfs').with({
+    it { is_expected.to contain_service('nfs').with({
         :ensure  => 'running',
         :require => 'Service[rpcbind]'
       })
     }
-    it { should create_file('/etc/init.d/sunrpc_tuning').with_content(/128/) }
-    it { should create_iptables__add_tcp_stateful_listen('nfs_client_tcp_ports') }
-    it { should create_iptables__add_udp_listen('nfs_client_udp_ports') }
-    it { should contain_service('sunrpc_tuning').with_require('File[/etc/init.d/sunrpc_tuning]') }
-    it { should contain_sysctl__value('sunrpc.tcp_slot_table_entries') }
-    it { should contain_sysctl__value('sunrpc.udp_slot_table_entries') }
+    it { is_expected.to create_file('/etc/init.d/sunrpc_tuning').with_content(/128/) }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('nfs_client_tcp_ports') }
+    it { is_expected.to create_iptables__add_udp_listen('nfs_client_udp_ports') }
+    it { is_expected.to contain_service('sunrpc_tuning').with_require('File[/etc/init.d/sunrpc_tuning]') }
+    it { is_expected.to contain_sysctl__value('sunrpc.tcp_slot_table_entries') }
+    it { is_expected.to contain_sysctl__value('sunrpc.udp_slot_table_entries') }
   end
 end


### PR DESCRIPTION
This commit replaces all `lsb*` facts with their (package-independent)
`operatingsystem*` counterparts.

Also:
- normalized common static module assets
- created metadata.json
- corrected lint errors
- moved parameter validations to the top of each class
- updated rspec tests to the new `expect` syntax

SIMP-674 #close
SIMP-398 #comment updated `pupmod-simp-nfs`
SIMP-667 #comment updated `pupmod-simp-nfs`
