### PR TITLE
(SIMP-926) Ensure the lvm2 package is latest

### DIFF
--- a/build/pupmod-nfs.spec
+++ b/build/pupmod-nfs.spec
@@ -62,6 +62,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Mar 16 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.2.0-0
+- Added an lvm2 class to ensure nfs-utils can upgrade.  This class
+  should be removed once the bug is fixed upstream.
+
 * Mon Mar 14 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.2.0-0
 - Updated to Semantic Versioning
 - Fixed the 'eval' variables in the templates

--- a/manifests/lvm2.pp
+++ b/manifests/lvm2.pp
@@ -1,0 +1,12 @@
+# == Class: nfs::lvm2
+# This class is used to counterract a bug in nfs-utils;
+# unless lvm2 is ensured latest, nfs-utils cannot upgrade.
+# It will be removed once the bug is fixed upstream.
+#
+class nfs::lvm2(
+  $ensure = 'latest'
+) {
+  package { 'lvm2':
+    ensure => $ensure
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -32,7 +32,11 @@ describe 'nfs' do
     it { is_expected.to create_class('nfs') }
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_file('/etc/exports') }
-    it { is_expected.to contain_package('nfs-utils').with_ensure('latest') }
+    it { is_expected.to contain_package('nfs-utils').with({
+        :ensure  => 'latest',
+        :require => 'Class[Nfs::Lvm2]'
+      })
+    }
     it { is_expected.to contain_package('nfs4-acl-tools').with_ensure('latest') }
     it { is_expected.to contain_service('nfslock').with({
         :ensure  => 'running',


### PR DESCRIPTION
Found a bug in the nfs-utils rpm which will not allow upgrades
unless the lvm2 package is the latest.  Created a one-off class
to manage the package which can be deleted once the bug is fixed
upstream.

SIMP-926 #close lvm2 latest