### PR TITLE
(SIMP-1525) Change permission on /etc/exports

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -57,7 +57,7 @@ class nfs::client (
 
     file { '/etc/exports':
       ensure  => 'file',
-      mode    => '0640',
+      mode    => '0644',
       owner   => 'root',
       group   => 'root',
       content => "\n"

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -112,7 +112,7 @@ class nfs::server (
 
   file { '/etc/exports':
     ensure => 'file',
-    mode   => '0640',
+    mode   => '0644',
     owner  => 'root',
     group  => 'root'
   }


### PR DESCRIPTION
  change permissions from 640 to 644 on /etc/exports.  644
  still meets security requirements.  Vagrant dies if it can't read the
  /etc/exports file.

SIMP-1525 #close