### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,10 +1,16 @@
-Requires: pupmod-herculesteam-augeasproviders_sysctl
-Requires: pupmod-puppetlabs-stdlib
-Requires: pupmod-simp-autofs >= 4.1.0
-Requires: pupmod-simp-iptables >= 4.1.4
-Requires: pupmod-simp-krb5 >= 5.0.5
-Requires: pupmod-simp-simpcat >= 4.0.0-0
-Requires: pupmod-simp-simplib >= 1.0.0-0
-Requires: pupmod-simp-stunnel >= 4.2.0-0
-Requires: pupmod-simp-sysctl >= 4.1.0-2
 Obsoletes: pupmod-nfs-test >= 0.0.1
+Requires: pupmod-herculesteam-augeasproviders_sysctl < 3.0.0-0
+Requires: pupmod-herculesteam-augeasproviders_sysctl >= 2.1.0-0
+Requires: pupmod-puppetlabs-stdlib
+Requires: pupmod-simp-iptables < 5.0.0-0
+Requires: pupmod-simp-iptables >= 4.1.4-0
+Requires: pupmod-simp-krb5 < 6.0.0-0
+Requires: pupmod-simp-krb5 >= 5.0.7-0
+Requires: pupmod-simp-simpcat < 6.0.0-0
+Requires: pupmod-simp-simpcat >= 5.0.1-0
+Requires: pupmod-simp-simplib < 2.0.0-0
+Requires: pupmod-simp-simplib >= 1.3.1-0
+Requires: pupmod-simp-stunnel < 5.0.0-0
+Requires: pupmod-simp-stunnel >= 4.2.8-0
+Requires: pupmod-simp-sysctl < 5.0.0-0
+Requires: pupmod-simp-sysctl >= 4.2.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "author": "simp",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",
@@ -15,36 +15,32 @@
   ],
   "dependencies": [
     {
-      "name": "simp/autofs",
-      "version_requirement": ">= 4.1.0"
-    },
-    {
       "name": "herculesteam/augeasproviders_sysctl",
-      "version_requirement": ">= 2.0.2"
+      "version_requirement": ">= 2.1.0 < 3.0.0"
     },
     {
       "name": "simp/iptables",
-      "version_requirement": ">= 4.1.4"
+      "version_requirement": ">= 4.1.4 < 5.0.0"
     },
     {
       "name": "simp/krb5",
-      "version_requirement": ">= 5.0.5"
+      "version_requirement": ">= 5.0.7 < 6.0.0"
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 3.4.0"
+      "version_requirement": ">= 5.0.1 < 6.0.0"
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "simp/stunnel",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.2.8 < 5.0.0"
     },
     {
       "name": "simp/sysctl",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 4.2.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-nfs`
SIMP-1627 #close