### PR TITLE
(SIMP-1692) Point fixtures to `5.X` branches

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,55 +2,55 @@
 fixtures:
   repositories:
     auditd:
-      repo: "git://github.com/simp/pupmod-simp-auditd"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-auditd
     augeasproviders_core:
-      repo: "git://github.com/simp/augeasproviders_core"
-      branch: "simp-master"
+      branch: 5.X
+      repo: git://github.com/simp/augeasproviders_core
     augeasproviders_grub:
-      repo: "git://github.com/simp/augeasproviders_grub"
-      branch: "simp-master"
+      branch: 5.X
+      repo: git://github.com/simp/augeasproviders_grub
     augeasproviders_sysctl:
-      repo: "git://github.com/simp/augeasproviders_sysctl"
-      branch: "simp-master"
+      branch: 5.X
+      repo: git://github.com/simp/augeasproviders_sysctl
     compliance_markup:
-      repo: "https://github.com/simp/pupmod-simp-compliance_markup"
-      branch: "master"
+      branch: 5.X
+      repo: https://github.com/simp/pupmod-simp-compliance_markup
     haveged:
-      repo: "https://github.com/simp/puppet-haveged"
-      branch: "simp-master"
+      branch: 5.X
+      repo: https://github.com/simp/puppet-haveged
     iptables:
-      repo: "git://github.com/simp/pupmod-simp-iptables"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-iptables
     krb5:
-      repo: "https://github.com/simp/pupmod-simp-krb5"
-      branch: "master"
+      branch: 5.X
+      repo: https://github.com/simp/pupmod-simp-krb5
     pki:
-      repo: "git://github.com/simp/pupmod-simp-pki"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-pki
     selinux:
-      repo: "git://github.com/simp/pupmod-simp-selinux"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-selinux
     simpcat:
-      repo: "git://github.com/simp/pupmod-simp-concat"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-concat
     simplib:
-      repo: "git://github.com/simp/pupmod-simp-simplib"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-simplib
     stdlib:
-      repo: "git://github.com/simp/puppetlabs-stdlib"
-      branch: "simp-master"
+      branch: 5.X
+      repo: git://github.com/simp/puppetlabs-stdlib
     stunnel:
-      repo: "git://github.com/simp/pupmod-simp-stunnel"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-stunnel
     svckill:
-      repo: "git://github.com/simp/pupmod-simp-svckill"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-svckill
     sysctl:
-      repo: "git://github.com/simp/pupmod-simp-sysctl"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-sysctl
     tcpwrappers:
-      repo: "git://github.com/simp/pupmod-simp-tcpwrappers"
-      branch: "master"
+      branch: 5.X
+      repo: git://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:
     nfs: "#{source_dir}"


### PR DESCRIPTION
This commit marks the transition of mainline SIMP development away from
4.x/5.x.  From this point on, the `master` branch will be used to target SIMP
6.x.

This commit updates `fixtures.yml` to reference the newly-created `5.X` branch
in each `simp/` repository.

SIMP-1692 #comment updated `.fixtures.yml` in nfs
