### PR TITLE
(SIMP-1684) Remove pupmod-simp-sysctl

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -49,9 +49,6 @@ fixtures:
     svckill:
       repo: git://github.com/simp/pupmod-simp-svckill
       branch: master
-    sysctl:
-      repo: git://github.com/simp/pupmod-simp-sysctl
-      branch: master
     tcpwrappers:
       repo: git://github.com/simp/pupmod-simp-tcpwrappers
       branch: master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Dec 01 2016 Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
+- Removed pupmod-simp-sysctl in favor of augeas-sysctl
+
 * Wed Nov 23 2016 Jeanne Greulich <jgreulich.simp@onyxpoint.com> - 5.0.0-0
 - update requirement versions
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -13,5 +13,3 @@ Requires: pupmod-simp-simplib < 3.0.0-0
 Requires: pupmod-simp-simplib >= 2.0.0-0
 Requires: pupmod-simp-stunnel < 6.0.0-0
 Requires: pupmod-simp-stunnel >= 5.0.0-0
-Requires: pupmod-simp-sysctl < 6.0.0-0
-Requires: pupmod-simp-sysctl >= 5.0.0-0

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -80,12 +80,13 @@ class nfs::client (
       Package['nfs-utils'],
       File['/etc/modprobe.d/nfs.conf']
     ],
-    notify  => Sysctl::Value['fs.nfs.nfs_callback_tcpport']
+    notify  => Sysctl['fs.nfs.nfs_callback_tcpport']
   }
 
-  sysctl::value { 'fs.nfs.nfs_callback_tcpport':
-    value  => $callback_port,
-    silent => true,
+  sysctl { 'fs.nfs.nfs_callback_tcpport':
+    ensure => 'present',
+    val    => $callback_port,
+    silent => true
   }
 
   file { '/etc/modprobe.d/nfs.conf':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,7 +183,7 @@ class nfs (
       enable     => true,
       hasrestart => true,
       hasstatus  => true,
-      require => File['/etc/sysconfig/nfs']
+      require    => File['/etc/sysconfig/nfs']
     }
 
     if (!$is_server and $is_client and $use_stunnel) {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -207,14 +207,17 @@ class nfs::server (
     pattern => $client_ips
   }
 
-  sysctl::value { 'sunrpc.tcp_slot_table_entries':
-    value  => $sunrpc_tcp_slot_table_entries,
-    silent => true,
+
+  sysctl { 'sunrpc.tcp_slot_table_entries':
+    ensure => 'present',
+    val    => $sunrpc_tcp_slot_table_entries,
+    silent => true, 
     notify => Service[$::nfs::service_names::nfs_server]
   }
 
-  sysctl::value { 'sunrpc.udp_slot_table_entries':
-    value  => $sunrpc_udp_slot_table_entries,
+  sysctl { 'sunrpc.udp_slot_table_entries':
+    ensure => 'present',
+    val    => $sunrpc_udp_slot_table_entries,
     silent => true,
     notify => Service[$::nfs::service_names::nfs_server]
   }
@@ -231,9 +234,9 @@ class nfs::server (
       Service[$::nfs::service_names::rpcbind] -> Service[$::nfs::service_names::rpcsvcgssd]
     }
 
-    Service[$::nfs::service_names::rpcbind] -> Sysctl::Value['sunrpc.tcp_slot_table_entries']
-    Service[$::nfs::service_names::rpcbind] -> Sysctl::Value['sunrpc.udp_slot_table_entries']
-    Sysctl::Value['sunrpc.tcp_slot_table_entries'] ~> Service[$::nfs::service_names::nfs_lock]
-    Sysctl::Value['sunrpc.udp_slot_table_entries'] ~> Service[$::nfs::service_names::nfs_lock]
+    Service[$::nfs::service_names::rpcbind] -> Sysctl['sunrpc.tcp_slot_table_entries']
+    Service[$::nfs::service_names::rpcbind] -> Sysctl['sunrpc.udp_slot_table_entries']
+    Sysctl['sunrpc.tcp_slot_table_entries'] ~> Service[$::nfs::service_names::nfs_lock]
+    Sysctl['sunrpc.udp_slot_table_entries'] ~> Service[$::nfs::service_names::nfs_lock]
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",
@@ -40,10 +40,6 @@
     },
     {
       "name": "simp/stunnel",
-      "version_requirement": ">= 5.0.0 < 6.0.0"
-    },
-    {
-      "name": "simp/sysctl",
       "version_requirement": ">= 5.0.0 < 6.0.0"
     }
   ],

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -12,7 +12,7 @@ describe 'nfs::client' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('nfs') }
           it { is_expected.to create_iptables__add_tcp_stateful_listen("nfs4_callback_port") }
-          it { is_expected.to create_sysctl__value('fs.nfs.nfs_callback_tcpport') }
+          it { is_expected.to create_sysctl('fs.nfs.nfs_callback_tcpport') }
           it { is_expected.to create_file('/etc/modprobe.d/nfs.conf').with_content(/options nfs callback_tcpport=876/) }
           it { is_expected.to create_exec('modprobe_nfs').that_requires('File[/etc/modprobe.d/nfs.conf]') }
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -54,8 +54,8 @@ describe 'nfs' do
           it { is_expected.to create_iptables__add_tcp_stateful_listen('nfs_client_tcp_ports') }
           it { is_expected.to create_iptables__add_udp_listen('nfs_client_udp_ports') }
           it { is_expected.to contain_service('sunrpc_tuning').with_require('File[/etc/init.d/sunrpc_tuning]') }
-          it { is_expected.to contain_sysctl__value('sunrpc.tcp_slot_table_entries') }
-          it { is_expected.to contain_sysctl__value('sunrpc.udp_slot_table_entries') }
+          it { is_expected.to contain_sysctl('sunrpc.tcp_slot_table_entries') }
+          it { is_expected.to contain_sysctl('sunrpc.udp_slot_table_entries') }
           it { is_expected.to contain_simpcat_fragment('sysconfig_nfs+server').without_content(%r(RPCSVCGSSDARGS=)) }
         end
 


### PR DESCRIPTION
Replaced sysctl::value with augeas 'sysctl' native type.

SIMP-1684 #comment done in nfs
SIMP-2242 #close