### PR TITLE
(SIMP-2285) Fix naming when using autofs

### DIFF
--- a/manifests/idmapd.pp
+++ b/manifests/idmapd.pp
@@ -57,7 +57,7 @@ class nfs::idmapd (
 
   $_startcmd = ('systemd' in $facts['init_systems']) ? {
     true    => "/usr/sbin/systemctl start ${::nfs::service_names::rpcidmapd}",
-    default => "/usr/sbin/service ${::nfs::service_names::rpcidmapd} start"
+    default => "/sbin/service ${::nfs::service_names::rpcidmapd} start"
   }
 
   service { $::nfs::service_names::rpcidmapd :

--- a/manifests/idmapd.pp
+++ b/manifests/idmapd.pp
@@ -55,7 +55,7 @@ class nfs::idmapd (
     notify  => Service[$::nfs::service_names::rpcidmapd]
   }
 
-  $_startcmd = 'systemd' in $facts['init_systems'] ? {
+  $_startcmd = ('systemd' in $facts['init_systems']) ? {
     true    => "/usr/sbin/systemctl start ${::nfs::service_names::rpcidmapd}",
     default => "/usr/sbin/service ${::nfs::service_names::rpcidmapd} start"
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class nfs (
   if $kerberos {
     include '::krb5'
 
-    if $::operatingsystem in ['RedHat', 'CentOS'] {
+    if ($::operatingsystem in ['RedHat', 'CentOS']) {
       if (versioncmp($::operatingsystemmajrelease,'6') > 0) {
         # This is here because the SELinux rules for directory includes in krb5
         # are broken.

--- a/manifests/server/export.pp
+++ b/manifests/server/export.pp
@@ -127,10 +127,10 @@ define nfs::server::export (
   }
 
   # We have to do this if we have a 'sec=sys' situation on EL7+
-  if 'sys' in $sec {
-    if $facts['os']['family'] == 'RedHat' {
-      if $facts['os']['name'] in ['RedHat','CentOS'] {
-        if $facts['os']['release']['major'] > '6' {
+  if ('sys' in $sec) {
+    if ($facts['os']['family'] == 'RedHat') {
+      if ($facts['os']['name'] in ['RedHat','CentOS']) {
+        if ($facts['os']['release']['major'] > '6') {
           ensure_resource('selboolean', 'nfsd_anon_write',
             {
               persistent => true,

--- a/manifests/service_names.pp
+++ b/manifests/service_names.pp
@@ -1,7 +1,7 @@
 # This class provides appropriate service names based on the operating system
 #
 class nfs::service_names {
-  if $facts['os']['name'] in ['RedHat', 'CentOS'] {
+  if ($facts['os']['name'] in ['RedHat', 'CentOS']) {
     $rpcbind   = 'rpcbind'
 
     if (versioncmp($facts['os']['release']['major'], '7') < 0) {

--- a/manifests/service_names.pp
+++ b/manifests/service_names.pp
@@ -2,11 +2,11 @@
 #
 class nfs::service_names {
   if ($facts['os']['name'] in ['RedHat', 'CentOS']) {
-    $rpcbind   = 'rpcbind'
 
     if (versioncmp($facts['os']['release']['major'], '7') < 0) {
       $nfs_lock    = 'nfslock'
       $nfs_server  = 'nfs'
+      $rpcbind     = 'rpcbind'
       $rpcgssd     = 'rpcgssd'
       $rpcidmapd   = 'rpcidmapd'
       $rpcsvcgssd  = 'rpcsvcgssd'
@@ -16,6 +16,7 @@ class nfs::service_names {
       $nfs_mountd  = 'nfs-mountd'
       $nfs_rquotad = 'nfs-rquotad'
       $nfs_server  = 'nfs-server'
+      $rpcbind     = 'rpcbind.socket'
       $rpcidmapd   = 'nfs-idmapd'
       $rpcgssd     = 'rpc-gssd'
 

--- a/spec/defines/client/mount_spec.rb
+++ b/spec/defines/client/mount_spec.rb
@@ -24,7 +24,7 @@ describe 'nfs::client::mount' do
       it { is_expected.to contain_class('nfs::client') }
 
       it {
-        is_expected.to contain_autofs__map__entry(clean_title).with_location("#{params[:nfs_server]}:#{params[:remote_path]}")
+        is_expected.to contain_autofs__map__entry(title).with_location("#{params[:nfs_server]}:#{params[:remote_path]}")
       }
 
       context 'without autofs' do
@@ -58,7 +58,7 @@ describe 'nfs::client::mount' do
         it_behaves_like "a fact set"
 
         it {
-          is_expected.to contain_autofs__map__entry(clean_title).with_location("127.0.0.1:#{params[:remote_path]}")
+          is_expected.to contain_autofs__map__entry(title).with_location("127.0.0.1:#{params[:remote_path]}")
         }
       end
 


### PR DESCRIPTION
When using autofs, and particularly, the wildcard mounts, the naming
conventions used in client::mount were incorrect.

SIMP-2285 #comment Fix client::mount resource naming