### PR TITLE
(SIMP-2663) Fix path for service and selection logic

### DIFF
--- a/manifests/idmapd.pp
+++ b/manifests/idmapd.pp
@@ -55,9 +55,9 @@ class nfs::idmapd (
     notify  => Service[$::nfs::service_names::rpcidmapd]
   }
 
-  $_startcmd = 'systemd' in $facts['init_systems'] ? {
+  $_startcmd = ('systemd' in $facts['init_systems']) ? {
     true    => "/usr/sbin/systemctl start ${::nfs::service_names::rpcidmapd}",
-    default => "/usr/sbin/service ${::nfs::service_names::rpcidmapd} start"
+    default => "/sbin/service ${::nfs::service_names::rpcidmapd} start"
   }
 
   service { $::nfs::service_names::rpcidmapd :


### PR DESCRIPTION
 - put logic for checking service in () to make sure it executed correctly
 - changed the path for CentOS server to /sbin/service

SIMP-2663 #comment  updated the same thing in nfs module