### PR TITLE
(SIMP-2777) Fix metadata.json versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Mar 10 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.1-0
+- Fixed the metadata.json dependencies for simp-tcpwrappers
+
 * Thu Dec 08 2016 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Updated global catalysts and strong typed.
 - Fix bug whereby the STATDARGS parameter in NFS sysconfig server

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -8,8 +8,8 @@ Requires: pupmod-simp-iptables >= 6.0.0-0
 Requires: pupmod-simp-krb5 < 8.0.0-0
 Requires: pupmod-simp-krb5 >= 7.0.0-0
 Requires: pupmod-simp-simpcat < 7.0.0-0
-Requires: pupmod-simp-simpcat >= 6.0.0-0
-Requires: pupmod-simp-simplib < 4.0.0-0
+Requires: puppetlabs-concat >= 2.2.0-0
+Requires: puppetlabs-concat < 3.0.0-0
 Requires: pupmod-simp-simplib >= 3.1.0-0
 Requires: pupmod-simp-stunnel < 7.0.0-0
 Requires: pupmod-simp-stunnel >= 6.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",
@@ -48,7 +48,7 @@
     },
     {
       "name": "simp/tcpwrappers",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The simp-tcpwrappers version in the metadata.json was incorrect. The
RPM dependencies were fine.

SIMP-2777 #close