### PR TITLE
(SIMP-3372) nfs - version/changelog cleanup as prep for tagging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
-* Mon Apr 24 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.4-0
+* Mon Apr 24 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.3-0
 - gssproxy ensured running when secure_nfs is true, el > 7.1
+- Confine puppet version in metadata.json
 
 * Tue Apr 11 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.3-0
 - nfs_anon_write selboolean is only applied if selinux is on.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "6.0.4",
+  "version": "6.0.3",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",


### PR DESCRIPTION
Last released version is 6.0.2, so all subsequent changes are for 6.0.3.