### PR TITLE
(SIMP-3613) nfs: Update to concat 3.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Aug 18 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.4-0
+- Update concat version in metadata.json
+
 * Mon Apr 24 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.3-0
 - gssproxy ensured running when secure_nfs is true, el > 7.1
 - Confine puppet version in metadata.json

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -9,7 +9,7 @@ Requires: pupmod-simp-krb5 < 8.0.0-0
 Requires: pupmod-simp-krb5 >= 7.0.0-0
 Requires: pupmod-simp-simpcat < 7.0.0-0
 Requires: puppetlabs-concat >= 2.2.0-0
-Requires: puppetlabs-concat < 3.0.0-0
+Requires: puppetlabs-concat < 4.0.0-0
 Requires: pupmod-simp-simplib >= 3.1.0-0
 Requires: pupmod-simp-stunnel < 7.0.0-0
 Requires: pupmod-simp-stunnel >= 6.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
concat 3.0.0 is fully backward compatible with 2.x.