### PR TITLE
(SIMP-4637) Use stunnel systemd service deps

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -21,9 +21,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib
-    stunnel:
-      repo: https://github.com/jeefberkey/pupmod-simp-stunnel
-      branch: SIMP-4598-systemd-deps
+    stunnel: https://github.com/simp/pupmod-simp-stunnel
     svckill: https://github.com/simp/pupmod-simp-svckill
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -21,7 +21,9 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib
     simp_options: https://github.com/simp/pupmod-simp-simp_options
     stdlib: https://github.com/simp/puppetlabs-stdlib
-    stunnel: https://github.com/simp/pupmod-simp-stunnel
+    stunnel:
+      repo: https://github.com/jeefberkey/pupmod-simp-stunnel
+      branch: SIMP-4598-systemd-deps
     svckill: https://github.com/simp/pupmod-simp-svckill
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers
   symlinks:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,7 +188,7 @@ pup5_latest-unit:
 
 # Acceptance tests
 # ==============================================================================
-acceptance-default:
+default:
   stage: acceptance
   tags:
     - beaker
@@ -199,7 +199,7 @@ acceptance-default:
   script:
     - bundle exec rake beaker:suites[default]
 
-acceptance-fips-default:
+default-fips:
   stage: acceptance
   tags:
     - beaker
@@ -211,7 +211,7 @@ acceptance-fips-default:
   script:
     - bundle exec rake beaker:suites[default]
 
-acceptance-stunnel:
+stunnel:
   stage: acceptance
   tags:
     - beaker
@@ -222,7 +222,7 @@ acceptance-stunnel:
   script:
     - bundle exec rake beaker:suites[stunnel]
 
-acceptance-fips-stunnel:
+stunnel-fips:
   stage: acceptance
   tags:
     - beaker

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@
 .cache_bundler: &cache_bundler
   cache:
     untracked: true
-    # An attempt at caching between runs (ala Travis CI)
+    # A broad attempt at caching between runs (ala Travis CI)
     key: "${CI_PROJECT_NAMESPACE}__bundler"
     paths:
       - '.vendor'
@@ -22,11 +22,16 @@
 
 .setup_bundler_env: &setup_bundler_env
   before_script:
-    - '(find .vendor | wc -l) || :'
-    - bundle check || gem install bundler --no-rdoc --no-ri
-    - rm -f Gemfile.lock
-    - rm -rf pkg/
-    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+    - 'echo Files in cache: $(find .vendor | wc -l) || :'
+    - 'export GEM_HOME=.vendor/gem_install'
+    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
+    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
+    - declare GEM_INSTALL=(gem install --no-document)
+    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
+    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'rm -rf pkg/ || :'
+    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
+
 
 .validation_checks: &validation_checks
   script:
@@ -52,7 +57,7 @@ stages:
 # Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup4.7-validation:
+pup4_7-validation:
   stage: validation
   tags:
     - docker
@@ -63,7 +68,7 @@ pup4.7-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.7-unit:
+pup4_7-unit:
   stage: unit
   tags:
     - docker
@@ -77,7 +82,7 @@ pup4.7-unit:
 
 # Puppet 4.8 for SIMP 6.0 + 6.1 support
 # --------------------------------------
-pup4.8-validation:
+pup4_8-validation:
   stage: validation
   tags:
     - docker
@@ -88,7 +93,7 @@ pup4.8-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.8-unit:
+pup4_8-unit:
   stage: unit
   tags:
     - docker
@@ -103,7 +108,7 @@ pup4.8-unit:
 # Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup4.10-validation:
+pup4_10-validation:
   stage: validation
   tags:
     - docker
@@ -114,7 +119,7 @@ pup4.10-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup4.10-unit:
+pup4_10-unit:
   stage: unit
   tags:
     - docker
@@ -129,7 +134,7 @@ pup4.10-unit:
 # Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
 # --------------------------------------
-pup5.3-validation:
+pup5_3-validation:
   stage: validation
   tags:
     - docker
@@ -140,7 +145,7 @@ pup5.3-validation:
   <<: *setup_bundler_env
   <<: *validation_checks
 
-pup5.3-unit:
+pup5_3-unit:
   stage: unit
   tags:
     - docker
@@ -155,7 +160,7 @@ pup5.3-unit:
 
 # Keep an eye on the latest puppet 5
 # ----------------------------------
-pup5.latest-validation:
+pup5_latest-validation:
   stage: validation
   tags:
     - docker
@@ -167,7 +172,7 @@ pup5.latest-validation:
   <<: *validation_checks
   allow_failure: true
 
-pup5.latest-unit:
+pup5_latest-unit:
   stage: unit
   tags:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: false
 
 bundler_args: --without development system_tests --path .vendor
 
+
 notifications:
   email: false
 
@@ -30,17 +31,20 @@ jobs:
 
   include:
     - stage: check
-      rvm: 2.1.9
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
         - bundle exec rake check:test_file
         - bundle exec rake pkg:check_version
+        - bundle exec rake lint
         - bundle exec rake metadata_lint
         - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
         - bundle exec puppet module build
 
     - stage: spec
-      rvm: 2.1.9
+      rvm: 2.4.1
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -54,12 +58,6 @@ jobs:
     - stage: spec
       rvm: 2.1.9
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
-      rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
       script:
         - bundle exec rake spec
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Apr 04 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.1-0
+- On systemd systems, the stunnel service is now a dependency of the NFS
+  servers and mounts managed by this module.
+
 * Mon Feb 12 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.0-0
 - Update upperbound on puppetlabs/concat version to < 5.0.0
 

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -118,7 +118,7 @@ define nfs::client::mount (
     $_mount_point = split($name,'wildcard-')[-1]
 
     # The map name is very particular
-    $_map_name = sprintf("/etc/autofs/%s.map", $_clean_name)
+    $_map_name = sprintf('/etc/autofs/%s.map', $_clean_name)
 
     autofs::map::master { $name:
       mount_point => $_mount_point,

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -55,14 +55,16 @@
 define nfs::client::mount (
   Simplib::Host                             $nfs_server,
   Stdlib::Absolutepath                      $remote_path,
-  Simplib::Port                             $port               = 2049,
-  Enum['nfs','nfs4']                        $nfs_version        = 'nfs4',
-  Optional[Simplib::Port]                   $v4_remote_port     = undef,
-  Enum['none','sys','krb5','krb5i','krb5p'] $sec                = 'sys',
-  String                                    $options            = 'hard,intr',
-  Boolean                                   $at_boot            = true,
-  Boolean                                   $autofs             = true,
-  Boolean                                   $autofs_map_to_user = false
+  Simplib::Port                             $port                 = 2049,
+  Enum['nfs','nfs4']                        $nfs_version          = 'nfs4',
+  Optional[Simplib::Port]                   $v4_remote_port       = undef,
+  Enum['none','sys','krb5','krb5i','krb5p'] $sec                  = 'sys',
+  String                                    $options              = 'hard,intr',
+  Boolean                                   $at_boot              = true,
+  Boolean                                   $autofs               = true,
+  Boolean                                   $autofs_map_to_user   = false,
+  Boolean                                   $stunnel_systemd_deps = true,
+  Optional[Array[String]]                   $stunnel_wantedby     = undef
 ) {
   if $autofs {
     if ($name !~ Stdlib::Absolutepath) and ($name !~ Pattern['^wildcard-']) {
@@ -81,11 +83,20 @@ define nfs::client::mount (
 
   include '::nfs::client'
 
+  if $stunnel_wantedby =~ Undef {
+    $_stunnel_wantedby = $stunnel_wantedby
+  }
+  else {
+    $_stunnel_wantedby = ['remote-fs-pre.target']
+  }
+
   nfs::client::mount::connection { $name:
-    nfs_server     => $nfs_server,
-    nfs_version    => $nfs_version,
-    nfs_port       => $port,
-    v4_remote_port => $v4_remote_port
+    nfs_server           => $nfs_server,
+    nfs_version          => $nfs_version,
+    nfs_port             => $port,
+    v4_remote_port       => $v4_remote_port,
+    stunnel_systemd_deps => $stunnel_systemd_deps,
+    stunnel_wantedby     => $_stunnel_wantedby
   }
 
   if $nfs_version == 'nfs4' {

--- a/manifests/client/mount/connection.pp
+++ b/manifests/client/mount/connection.pp
@@ -65,8 +65,8 @@ define nfs::client::mount::connection (
     ensure_resource('iptables::listen::tcp_stateful',
       "nfs_callback_${nfs_server}",
       {
-        'trusted_nets' => [$nfs_server],
-        'dports'       => $nfs::client::callback_port
+        trusted_nets => [$nfs_server],
+        dports       => $nfs::client::callback_port
       }
     )
   }

--- a/manifests/client/mount/connection.pp
+++ b/manifests/client/mount/connection.pp
@@ -22,7 +22,9 @@ define nfs::client::mount::connection (
   Simplib::Host           $nfs_server,
   Enum['nfs','nfs4']      $nfs_version,
   Simplib::Port           $nfs_port       = 2049,
-  Optional[Simplib::Port] $v4_remote_port = undef
+  Optional[Simplib::Port] $v4_remote_port = undef,
+  Boolean                 $stunnel_systemd_deps = true,
+  Array[String]           $stunnel_wantedby     = []
 ) {
   assert_private()
 
@@ -47,7 +49,9 @@ define nfs::client::mount::connection (
       ensure_resource('nfs::client::stunnel::v4',
         "${nfs_server}:${nfs_port}",
         {
-          nfs_connect_port => $v4_remote_port
+          nfs_connect_port     => $v4_remote_port,
+          stunnel_systemd_deps => $stunnel_systemd_deps,
+          stunnel_wantedby     => $stunnel_wantedby,
         }
       )
     }
@@ -61,8 +65,8 @@ define nfs::client::mount::connection (
     ensure_resource('iptables::listen::tcp_stateful',
       "nfs_callback_${nfs_server}",
       {
-        trusted_nets => [$nfs_server],
-        dports       => $nfs::client::callback_port
+        'trusted_nets' => [$nfs_server],
+        'dports'       => $nfs::client::callback_port
       }
     )
   }

--- a/manifests/client/stunnel.pp
+++ b/manifests/client/stunnel.pp
@@ -57,54 +57,72 @@ class nfs::client::stunnel (
   Simplib::Port $lockd_connect_port      = 32804,
   Simplib::Port $mountd_connect_port     = 8920,
   Simplib::Port $statd_connect_port      = 6620,
-  Integer[0]    $stunnel_verify          = $nfs::client::stunnel_verify
+  Integer[0]    $stunnel_verify          = $nfs::client::stunnel_verify,
+  Boolean       $stunnel_systemd_deps    = $nfs::stunnel_systemd_deps,
+  Array[String] $stunnel_wantedby        = $nfs::stunnel_wantedby
 ) inherits ::nfs::client {
+
+  if $stunnel_systemd_deps {
+    $_stunnel_wantedby = [
+      'remote-fs-pre.target',
+    ]
+  }
+  else {
+    $_stunnel_wantedby = undef
+  }
+
   # Don't do this if you're running on yourself because, well, it's bad!
   if !host_is_me($nfs_server) {
     stunnel::instance { 'nfs_client':
-      connect        => ["${nfs_server}:${nfs_connect_port}"],
-      accept         => "127.0.0.1:${nfs_accept_port}",
-      verify         => $stunnel_verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      connect          => ["${nfs_server}:${nfs_connect_port}"],
+      accept           => "127.0.0.1:${nfs_accept_port}",
+      verify           => $stunnel_verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
 
     stunnel::instance { 'nfs_client_portmapper':
-      connect        => ["${nfs_server}:${portmapper_connect_port}"],
-      accept         => "127.0.0.1:${portmapper_accept_port}",
-      verify         => $stunnel_verify,
-      require        => Service[$::nfs::service_names::rpcbind],
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      connect          => ["${nfs_server}:${portmapper_connect_port}"],
+      accept           => "127.0.0.1:${portmapper_accept_port}",
+      verify           => $stunnel_verify,
+      require          => Service[$::nfs::service_names::rpcbind],
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
 
     stunnel::instance { 'nfs_client_rquotad':
-      connect        => ["${nfs_server}:${rquotad_connect_port}"],
-      accept         => "127.0.0.1:${::nfs::rquotad_port}",
-      verify         => $stunnel_verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      connect          => ["${nfs_server}:${rquotad_connect_port}"],
+      accept           => "127.0.0.1:${::nfs::rquotad_port}",
+      verify           => $stunnel_verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'nfs_client_lockd':
-      connect        => ["${nfs_server}:${lockd_connect_port}"],
-      accept         => "127.0.0.1:${::nfs::lockd_tcpport}",
-      verify         => $stunnel_verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      connect          => ["${nfs_server}:${lockd_connect_port}"],
+      accept           => "127.0.0.1:${::nfs::lockd_tcpport}",
+      verify           => $stunnel_verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'nfs_client_mountd':
-      connect        => ["${nfs_server}:${mountd_connect_port}"],
-      accept         => "127.0.0.1:${::nfs::mountd_port}",
-      verify         => $stunnel_verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      connect          => ["${nfs_server}:${mountd_connect_port}"],
+      accept           => "127.0.0.1:${::nfs::mountd_port}",
+      verify           => $stunnel_verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'nfs_client_status':
-      connect        => ["${nfs_server}:${statd_connect_port}"],
-      accept         => "127.0.0.1:${::nfs::statd_port}",
-      verify         => $stunnel_verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      connect          => ["${nfs_server}:${statd_connect_port}"],
+      accept           => "127.0.0.1:${::nfs::statd_port}",
+      verify           => $stunnel_verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
   }
 }

--- a/manifests/client/stunnel/v4.pp
+++ b/manifests/client/stunnel/v4.pp
@@ -23,15 +23,15 @@ define nfs::client::stunnel::v4 (
   include 'nfs::client'
   include 'nfs::service_names'
 
+  if $name !~ Simplib::Host::Port {
+    fail('$name must be a Simplib::Host::Port => `<host>:<port>`')
+  }
+
   if $stunnel_systemd_deps and ($facts['os']['release']['major'] > '6') {
     $_stunnel_wantedby = ['remote-fs-pre.target']
   }
   else {
     $_stunnel_wantedby = undef
-  }
-
-  if $name !~ Simplib::Host::Port {
-    fail('$name must be a Simplib::Host::Port => `<host>:<port>`')
   }
 
   $_target_parts = split($name, ':')

--- a/manifests/client/stunnel/v4.pp
+++ b/manifests/client/stunnel/v4.pp
@@ -24,16 +24,7 @@ define nfs::client::stunnel::v4 (
   include 'nfs::service_names'
 
   if $stunnel_systemd_deps and ($facts['os']['release']['major'] > '6') {
-    $_stunnel_wantedby = [
-      $nfs::service_names::nfs_lock,
-      $nfs::service_names::nfs_mountd,
-      $nfs::service_names::nfs_rquotad,
-      $nfs::service_names::nfs_server,
-      $nfs::service_names::rpcbind,
-      $nfs::service_names::rpcidmapd,
-      $nfs::service_names::rpcgssd,
-      $nfs::service_names::rpcsvcgssd,
-    ]
+    $_stunnel_wantedby = ['remote-fs-pre.target']
   }
   else {
     $_stunnel_wantedby = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,8 +121,10 @@ class nfs (
   Boolean              $tcpwrappers            = simplib::lookup('simp_options::tcpwrappers', { 'default_value' => false }),
   Boolean              $stunnel                = simplib::lookup('simp_options::stunnel', { 'default_value' => false }),
   Boolean              $stunnel_tcp_nodelay    = true,
-  Array[String]        $stunnel_socket_options = []
-){
+  Array[String]        $stunnel_socket_options = [],
+  Boolean              $stunnel_systemd_deps   = true,
+  Array[String]        $stunnel_wantedby       = []
+) {
 
   if $stunnel_tcp_nodelay {
     $_stunnel_socket_options = $stunnel_socket_options + [

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,6 +7,6 @@
 class nfs::install (
   Enum['latest','present','absent'] $ensure = 'latest'
 ){
-  package { 'nfs-utils': ensure  => $ensure }
+  package { 'nfs-utils':      ensure => $ensure }
   package { 'nfs4-acl-tools': ensure => $ensure }
 }

--- a/manifests/server/stunnel.pp
+++ b/manifests/server/stunnel.pp
@@ -35,24 +35,45 @@
 class nfs::server::stunnel (
   Integer[3,4]     $version                = 4,
   Integer          $verify                 = 2,
-  Simplib::Netlist $trusted_nets           = $::nfs::server::trusted_nets,
+  Simplib::Netlist $trusted_nets           = $nfs::server::trusted_nets,
   Simplib::IP      $nfs_accept_address     = '0.0.0.0',
   Simplib::Port    $nfs_accept_port        = 20490,
   Simplib::Port    $portmapper_accept_port = 1110,
   Simplib::Port    $rquotad_accept_port    = 8750,
   Simplib::Port    $nlockmgr_accept_port   = 32804,
   Simplib::Port    $mountd_accept_port     = 8920,
-  Simplib::Port    $status_accept_port     = 6620
+  Simplib::Port    $status_accept_port     = 6620,
+  Boolean          $stunnel_systemd_deps   = $nfs::stunnel_systemd_deps,
+  Array[String]    $stunnel_wantedby       = $nfs::stunnel_wantedby
 ) {
+  include '::nfs::service_names'
+
+  if $stunnel_systemd_deps and ($facts['os']['release']['major'] > '6') {
+    $_stunnel_wantedby = [
+      $nfs::service_names::nfs_lock,
+      $nfs::service_names::nfs_mountd,
+      $nfs::service_names::nfs_rquotad,
+      $nfs::service_names::nfs_server,
+      $nfs::service_names::rpcbind,
+      $nfs::service_names::rpcidmapd,
+      $nfs::service_names::rpcgssd,
+      $nfs::service_names::rpcsvcgssd,
+    ]
+  }
+  else {
+    $_stunnel_wantedby = undef
+  }
+
   if $version == 4 {
     stunnel::instance { 'nfs':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => [2049],
-      accept         => "${nfs_accept_address}:${nfs_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => [2049],
+      accept           => "${nfs_accept_address}:${nfs_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
 
     $stunnel_port_override = [ $nfs_accept_port ]
@@ -61,58 +82,64 @@ class nfs::server::stunnel (
   }
   else {
     stunnel::instance { 'nfs':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => ['2049'],
-      accept         => "${nfs_accept_address}:${nfs_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => ['2049'],
+      accept           => "${nfs_accept_address}:${nfs_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'portmapper':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => ['111'],
-      accept         => "${nfs_accept_address}:${portmapper_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => ['111'],
+      accept           => "${nfs_accept_address}:${portmapper_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'rquotad':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => [$::nfs::rquotad_port],
-      accept         => "${nfs_accept_address}:${rquotad_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => [$::nfs::rquotad_port],
+      accept           => "${nfs_accept_address}:${rquotad_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'nlockmgr':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => [$::nfs::lockd_tcpport],
-      accept         => "${nfs_accept_address}:${nlockmgr_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => [$::nfs::lockd_tcpport],
+      accept           => "${nfs_accept_address}:${nlockmgr_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'mountd':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => [$::nfs::mountd_port],
-      accept         => "${nfs_accept_address}:${mountd_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => [$::nfs::mountd_port],
+      accept           => "${nfs_accept_address}:${mountd_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
     stunnel::instance { 'status':
-      client         => false,
-      trusted_nets   => $trusted_nets,
-      connect        => [$::nfs::statd_port],
-      accept         => "${nfs_accept_address}:${status_accept_port}",
-      verify         => $verify,
-      socket_options => $::nfs::_stunnel_socket_options,
-      tag            => ['nfs']
+      client           => false,
+      trusted_nets     => $trusted_nets,
+      connect          => [$::nfs::statd_port],
+      accept           => "${nfs_accept_address}:${status_accept_port}",
+      verify           => $verify,
+      socket_options   => $::nfs::_stunnel_socket_options,
+      systemd_wantedby => $_stunnel_wantedby,
+      tag              => ['nfs']
     }
 
     Service[$::nfs::service_names::nfs_server] -> Stunnel::Instance['nfs']

--- a/manifests/service_names.pp
+++ b/manifests/service_names.pp
@@ -12,19 +12,19 @@ class nfs::service_names {
       $rpcsvcgssd  = 'rpcsvcgssd'
     }
     else {
-      $nfs_lock    = 'rpc-statd'
-      $nfs_mountd  = 'nfs-mountd'
-      $nfs_rquotad = 'nfs-rquotad'
-      $nfs_server  = 'nfs-server'
+      $nfs_lock    = 'rpc-statd.service'
+      $nfs_mountd  = 'nfs-mountd.service'
+      $nfs_rquotad = 'nfs-rquotad.service'
+      $nfs_server  = 'nfs-server.service'
       $rpcbind     = 'rpcbind.socket'
-      $rpcidmapd   = 'nfs-idmapd'
-      $rpcgssd     = 'rpc-gssd'
+      $rpcidmapd   = 'nfs-idmapd.service'
+      $rpcgssd     = 'rpc-gssd.service'
 
       if (versioncmp($facts['os']['release']['full'], '7.1') < 0) {
-        $rpcsvcgssd  = 'rpc-svcgssd'
+        $rpcsvcgssd  = 'rpc-svcgssd.service'
       }
       else {
-        $rpcsvcgssd  = 'gssproxy'
+        $rpcsvcgssd  = 'gssproxy.service'
       }
     }
   }

--- a/manifests/service_names.pp
+++ b/manifests/service_names.pp
@@ -12,6 +12,10 @@ class nfs::service_names {
       $rpcsvcgssd  = 'rpcsvcgssd'
     }
     else {
+      # Services here should use the fully qualified service name
+      # When Puppet runs `systemctl is-enabled <service>` without `.service`,
+      # it doesn't know what to check the enabled status of, and returns
+      # unknown
       $nfs_lock    = 'rpc-statd.service'
       $nfs_mountd  = 'nfs-mountd.service'
       $nfs_rquotad = 'nfs-rquotad.service'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "simp/stunnel",
-      "version_requirement": ">= 6.3.0 < 7.0.0"
+      "version_requirement": ">= 6.3.1 < 7.0.0"
     },
     {
       "name": "simp/tcpwrappers",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -61,4 +61,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 512
+  vagrant_memsize: 256

--- a/spec/acceptance/suites/default/00_basic_test_spec.rb
+++ b/spec/acceptance/suites/default/00_basic_test_spec.rb
@@ -152,7 +152,7 @@ nfs::is_server : #IS_SERVER#
             autofs_client_manifest = autofs_client_manifest + "\n" + server_manifest
           end
 
-          apply_manifest_on(host, autofs_client_manifest)
+          # apply_manifest_on(host, autofs_client_manifest)
           apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
           on(host, %{puppet resource service autofs ensure=stopped})

--- a/spec/acceptance/suites/default/00_basic_test_spec.rb
+++ b/spec/acceptance/suites/default/00_basic_test_spec.rb
@@ -152,8 +152,8 @@ nfs::is_server : #IS_SERVER#
             autofs_client_manifest = autofs_client_manifest + "\n" + server_manifest
           end
 
-          # apply_manifest_on(host, autofs_client_manifest)
-          apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
+          apply_manifest_on(host, autofs_client_manifest)
+          # apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
           on(host, %{puppet resource service autofs ensure=stopped})
         end

--- a/spec/acceptance/suites/default/00_basic_test_spec.rb
+++ b/spec/acceptance/suites/default/00_basic_test_spec.rb
@@ -4,21 +4,6 @@ test_name 'nfs basic'
 
 describe 'nfs basic' do
 
-  before(:context) do
-    hosts.each do |host|
-      interfaces = fact_on(host, 'interfaces').strip.split(',')
-      interfaces.delete_if do |x|
-        x =~ /^lo/
-      end
-
-      interfaces.each do |iface|
-        if fact_on(host, "ipaddress_#{iface}").strip.empty?
-          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
-        end
-      end
-    end
-  end
-
   servers = hosts_with_role( hosts, 'nfs_server' )
   clients = hosts_with_role( hosts, 'client' )
 
@@ -120,7 +105,7 @@ nfs::is_server : #IS_SERVER#
   context "as a server" do
     servers.each do |host|
       it 'should export a directory' do
-        apply_manifest_on(host, server_manifest)
+        apply_manifest_on(host, server_manifest, :catch_failures => true)
       end
     end
   end
@@ -146,7 +131,7 @@ nfs::is_server : #IS_SERVER#
           end
 
           host.mkdir_p("/mnt/#{server}")
-          apply_manifest_on(host, client_manifest)
+          apply_manifest_on(host, client_manifest, :catch_failures => true)
           on(host, %(grep -q 'This is a test' /mnt/#{server}/test_file))
           on(host, %{puppet resource mount /mnt/#{server} ensure=absent})
         end
@@ -168,6 +153,8 @@ nfs::is_server : #IS_SERVER#
           end
 
           apply_manifest_on(host, autofs_client_manifest)
+          apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
+          apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
           on(host, %{puppet resource service autofs ensure=stopped})
         end
       end

--- a/spec/acceptance/suites/default/02_krb5_test_spec.rb
+++ b/spec/acceptance/suites/default/02_krb5_test_spec.rb
@@ -254,8 +254,8 @@ nfs::is_server : #IS_SERVER#
             autofs_client_manifest = autofs_client_manifest + "\n" + krb5_client_manifest
           end
 
-          apply_manifest_on(host, autofs_client_manifest)
-          # apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
+          # apply_manifest_on(host, autofs_client_manifest)
+          apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
 
           on(host, %{puppet resource service autofs ensure=stopped})

--- a/spec/acceptance/suites/default/02_krb5_test_spec.rb
+++ b/spec/acceptance/suites/default/02_krb5_test_spec.rb
@@ -4,21 +4,6 @@ test_name 'nfs krb5'
 
 describe 'nfs krb5' do
 
-  before(:context) do
-    hosts.each do |host|
-      interfaces = fact_on(host, 'interfaces').strip.split(',')
-      interfaces.delete_if do |x|
-        x =~ /^lo/
-      end
-
-      interfaces.each do |iface|
-        if fact_on(host, "ipaddress_#{iface}").strip.empty?
-          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
-        end
-      end
-    end
-  end
-
   servers = hosts_with_role( hosts, 'nfs_server' )
   clients = hosts_with_role( hosts, 'nfs_client' )
 
@@ -181,7 +166,7 @@ nfs::is_server : #IS_SERVER#
       end
 
       it 'should export a directory' do
-        apply_manifest_on(host, server_manifest)
+        apply_manifest_on(host, server_manifest, :catch_failures => true)
       end
     end
   end
@@ -226,7 +211,7 @@ nfs::is_server : #IS_SERVER#
           end
 
           set_hieradata_on(host, hdata)
-          apply_manifest_on(host, _manifest, {:catch_failures => true})
+          apply_manifest_on(host, _manifest, :catch_failures => true)
         end
 
         it "should mount a directory on the #{server} server" do
@@ -248,7 +233,7 @@ nfs::is_server : #IS_SERVER#
           end
 
           host.mkdir_p("/mnt/#{server}")
-          apply_manifest_on(host, client_manifest)
+          apply_manifest_on(host, client_manifest, :catch_failures => true)
           on(host, %(grep -q 'This is a test' /mnt/#{server}/test_file))
           on(host, %{puppet resource mount /mnt/#{server} ensure=unmounted})
         end
@@ -270,6 +255,9 @@ nfs::is_server : #IS_SERVER#
           end
 
           apply_manifest_on(host, autofs_client_manifest)
+          apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
+          apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
+
           on(host, %{puppet resource service autofs ensure=stopped})
         end
       end

--- a/spec/acceptance/suites/default/02_krb5_test_spec.rb
+++ b/spec/acceptance/suites/default/02_krb5_test_spec.rb
@@ -254,8 +254,8 @@ nfs::is_server : #IS_SERVER#
             autofs_client_manifest = autofs_client_manifest + "\n" + krb5_client_manifest
           end
 
-          # apply_manifest_on(host, autofs_client_manifest)
-          apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
+          apply_manifest_on(host, autofs_client_manifest)
+          # apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
 
           on(host, %{puppet resource service autofs ensure=stopped})

--- a/spec/acceptance/suites/default/02_krb5_test_spec.rb
+++ b/spec/acceptance/suites/default/02_krb5_test_spec.rb
@@ -254,7 +254,7 @@ nfs::is_server : #IS_SERVER#
             autofs_client_manifest = autofs_client_manifest + "\n" + krb5_client_manifest
           end
 
-          apply_manifest_on(host, autofs_client_manifest)
+          # apply_manifest_on(host, autofs_client_manifest)
           apply_manifest_on(host, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(host, autofs_client_manifest, catch_changes: true)
 

--- a/spec/acceptance/suites/stunnel/00_basic_test_spec.rb
+++ b/spec/acceptance/suites/stunnel/00_basic_test_spec.rb
@@ -156,12 +156,7 @@ nfs::is_server : #IS_SERVER#
             on(client, 'systemctl stop rpcbind.socket')
           end
 
-          apply_manifest_on(client, autofs_client_manifest)
-          if client.host_hash['platform'] =~ /el-7/
-            retry_on(client, 'systemctl is-active remote-fs-pre.target')
-          else
-            sleep 15
-          end
+          # apply_manifest_on(client, autofs_client_manifest)
           apply_manifest_on(client, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(client, autofs_client_manifest, catch_changes: true)
 

--- a/spec/acceptance/suites/stunnel/00_basic_test_spec.rb
+++ b/spec/acceptance/suites/stunnel/00_basic_test_spec.rb
@@ -156,12 +156,26 @@ nfs::is_server : #IS_SERVER#
             on(client, 'systemctl stop rpcbind.socket')
           end
 
-          # apply_manifest_on(client, autofs_client_manifest)
           apply_manifest_on(client, autofs_client_manifest, catch_failures: true)
           apply_manifest_on(client, autofs_client_manifest, catch_changes: true)
-
-          on(client, %{puppet resource service autofs ensure=stopped})
         end
+      end
+    end
+  end
+
+  context 'should cleanup client mounts' do
+    clients.each do |client|
+      servers.each do |server|
+        it 'should unmount test mounts' do
+          on(client, %{puppet resource mount /mnt/#{server} ensure=absent})
+        end
+      end
+      it 'should stop autofs' do
+        on(client, %{puppet resource service autofs ensure=stopped})
+      end
+      it 'should delete configuration from this test' do
+        on(client, 'rm -f /etc/autofs.conf')
+        on(client, 'rm -f /etc/autofs/*')
       end
     end
   end

--- a/spec/acceptance/suites/stunnel/03_stunnel_test_spec.rb
+++ b/spec/acceptance/suites/stunnel/03_stunnel_test_spec.rb
@@ -172,6 +172,7 @@ nfs::is_server : #IS_SERVER#
           # wait for it to come back up, then a little more
           on(client, 'uptime')
           sleep 15
+          apply_manifest_on(client, client_manifest, catch_failures: true)
           apply_manifest_on(client, client_manifest, catch_changes: true)
         end
       end

--- a/spec/acceptance/suites/stunnel/03_stunnel_test_spec.rb
+++ b/spec/acceptance/suites/stunnel/03_stunnel_test_spec.rb
@@ -169,6 +169,9 @@ nfs::is_server : #IS_SERVER#
 
         it 'should run cleanly after reboot' do
           client.reboot
+          # wait for it to come back up, then a little more
+          on(client, 'uptime')
+          sleep 15
           apply_manifest_on(client, client_manifest, catch_changes: true)
         end
       end

--- a/spec/acceptance/suites/stunnel/03_stunnel_test_spec.rb
+++ b/spec/acceptance/suites/stunnel/03_stunnel_test_spec.rb
@@ -159,7 +159,6 @@ nfs::is_server : #IS_SERVER#
         it "should mount a directory on #{server}" do
           client.mkdir_p("/mnt/#{server}")
 
-          # apply_manifest_on(client, client_manifest)
           apply_manifest_on(client, client_manifest, catch_failures: true)
           apply_manifest_on(client, client_manifest, catch_changes: true)
 

--- a/spec/classes/client/stunnel_spec.rb
+++ b/spec/classes/client/stunnel_spec.rb
@@ -1,14 +1,8 @@
 require 'spec_helper'
 
 describe 'nfs::client::stunnel' do
-  before(:each) do
-    Puppet::Parser::Functions.newfunction('assert_private') do |f|
-      f.stubs(:call).returns(true)
-    end
-  end
-
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:facts) { facts }
 
       let(:params) {{
@@ -17,7 +11,12 @@ describe 'nfs::client::stunnel' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to create_class('nfs::client::stunnel') }
-      it { is_expected.to create_stunnel__instance('nfs_client') }
+      it { is_expected.to create_stunnel__instance('nfs_client').with_systemd_wantedby(['remote-fs-pre.target']) }
+      if facts[:os][:release][:major] == '7'
+        it { is_expected.to create_file('/etc/systemd/system/stunnel_managed_by_puppet_nfs_client.service') \
+          .with_content(/WantedBy=remote-fs-pre.target/)
+        }
+      end
     end
   end
 end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,14 +1,8 @@
 require 'spec_helper'
 
 describe 'nfs::client' do
-  before(:each) do
-    Puppet::Parser::Functions.newfunction('assert_private') do |f|
-      f.stubs(:call).returns(true)
-    end
-  end
-
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:facts) { facts }
 
       context "on #{os}" do

--- a/spec/classes/idmapd_spec.rb
+++ b/spec/classes/idmapd_spec.rb
@@ -1,23 +1,22 @@
 require 'spec_helper'
 
 describe 'nfs::idmapd' do
-  before(:each) do
-    Puppet::Parser::Functions.newfunction('assert_private') do |f|
-      f.stubs(:call).returns(true)
+  on_supported_os.each do |os, facts|
+    before(:each) do
+      Puppet::Parser::Functions.newfunction('assert_private') do |f|
+        f.stubs(:call).returns(true)
+      end
     end
-  end
 
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts){ facts }
+    context "on #{os}" do
+      let(:facts){ facts }
 
-        let(:pre_condition) { 'class { "nfs": is_server => true }' }
+      let(:pre_condition) { 'class { "nfs": is_server => true }' }
 
-        context 'with default parameters' do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('nfs::idmapd') }
-          it { is_expected.to create_file('/etc/idmapd.conf').with_content( <<EOM
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('nfs::idmapd') }
+        it { is_expected.to create_file('/etc/idmapd.conf').with_content( <<EOM
 # This file is managed by Puppet. Any changes made to the file will be
 # overwritten at the next Puppet run.
 [General]
@@ -38,19 +37,19 @@ Method = nsswitch
 
 # This is not yet supported by the SIMP configuration.
 EOM
-          )}
-        end
+        )}
+      end
 
-        context 'with optional parameters set' do
-          let(:params) {{
-            :verbosity          => 2,
-            :local_realms       => ['realm1', 'realm2'],
-            :gss_methods        => ['nsswitch'],
-            :static_translation => { 'key1' => 'value1', 'key2' => 'value2' }
-          }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('nfs::idmapd') }
-          it { is_expected.to create_file('/etc/idmapd.conf').with_content( <<EOM
+      context 'with optional parameters set' do
+        let(:params) {{
+          :verbosity          => 2,
+          :local_realms       => ['realm1', 'realm2'],
+          :gss_methods        => ['nsswitch'],
+          :static_translation => { 'key1' => 'value1', 'key2' => 'value2' }
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('nfs::idmapd') }
+        it { is_expected.to create_file('/etc/idmapd.conf').with_content( <<EOM
 # This file is managed by Puppet. Any changes made to the file will be
 # overwritten at the next Puppet run.
 [General]
@@ -76,8 +75,7 @@ key2 = value2
 
 # This is not yet supported by the SIMP configuration.
 EOM
-          )}
-        end
+        )}
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -39,13 +39,13 @@ describe 'nfs' do
           })
         }
 
-        if ['RedHat','CentOS'].include?(facts[:operatingsystem]) && facts[:operatingsystemmajrelease].to_s < '7'
+        if facts[:operatingsystemmajrelease].to_s < '7'
           it { is_expected.to contain_service('nfs').with({
               :ensure  => 'running'
             })
           }
         else
-          it { is_expected.to contain_service('nfs-server').with({
+          it { is_expected.to contain_service('nfs-server.service').with({
               :ensure  => 'running'
             })
           }
@@ -86,18 +86,16 @@ describe 'nfs' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=yes/) }
 
-        if facts[:osfamily] == 'RedHat'
-          if facts[:operatingsystemmajrelease] >= '7'
-            it { is_expected.to contain_service('rpc-gssd').with(:ensure => 'running') }
-            if facts[:os][:release][:full] >= '7.1.0'
-              it { is_expected.to contain_service('gssproxy').with(:ensure => 'running') }
-            else
-              it { is_expected.to contain_service('rpc-svcgssd').with(:ensure => 'running') }
-            end
+        if facts[:operatingsystemmajrelease] >= '7'
+          it { is_expected.to contain_service('rpc-gssd.service').with(:ensure => 'running') }
+          if facts[:os][:release][:full] >= '7.1.0'
+            it { is_expected.to contain_service('gssproxy.service').with(:ensure => 'running') }
           else
-            it { is_expected.to contain_service('rpcgssd').with(:ensure => 'running') }
-            it { is_expected.to contain_service('rpcsvcgssd').with(:ensure => 'running') }
+            it { is_expected.to contain_service('rpc-svcgssd.service').with(:ensure => 'running') }
           end
+        else
+          it { is_expected.to contain_service('rpcgssd').with(:ensure => 'running') }
+          it { is_expected.to contain_service('rpcsvcgssd').with(:ensure => 'running') }
         end
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,11 +61,11 @@ describe 'nfs' do
         context "as a server with custom args" do
           let(:hieradata) { 'rpcgssdargs' }
           let(:params) {{
-            :is_server => true,
+            :is_server   => true,
             :tcpwrappers => true,
-            :stunnel => true,
-            :kerberos => true,
-            :firewall => true
+            :stunnel     => true,
+            :kerberos    => true,
+            :firewall    => true
           }}
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('nfs') }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,108 +1,106 @@
 require 'spec_helper'
 
 describe 'nfs' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts){ facts }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts){ facts }
 
-        shared_examples_for "a fact set" do
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_class('nfs') }
-          it { is_expected.to contain_package('nfs-utils').with({
-              :ensure  => 'latest'
-            })
-          }
-          it { is_expected.to contain_package('nfs4-acl-tools').with_ensure('latest') }
-        end
-
-        if os =~ /(?:redhat|centos)-(\d+)/
-          it_behaves_like "a fact set"
-          it { is_expected.to contain_concat__fragment('nfs_init').with_content(%r(MOUNTD_PORT=20048)) }
-        end
-
-        context "as a server with default params" do
-          let(:params){{
-            :is_server => true
-          }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('nfs') }
-          it { is_expected.to contain_class('nfs::client') }
-          it { is_expected.to contain_class('nfs::server') }
-          it { is_expected.to_not contain_class('tcpwrappers') }
-          it { is_expected.to_not contain_class('krb5') }
-          it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=no/) }
-          it { is_expected.to create_concat('/etc/sysconfig/nfs') }
-          it { is_expected.to create_exec('nfs_re-export').with({
-              :command     => '/usr/sbin/exportfs -ra',
-              :refreshonly => true,
-              :require     => 'Package[nfs-utils]'
-            })
-          }
-
-          if ['RedHat','CentOS'].include?(facts[:operatingsystem]) && facts[:operatingsystemmajrelease].to_s < '7'
-            it { is_expected.to contain_service('nfs').with({
-                :ensure  => 'running'
-              })
-            }
-          else
-            it { is_expected.to contain_service('nfs-server').with({
-                :ensure  => 'running'
-              })
-            }
-          end
-          it { is_expected.to create_file('/etc/init.d/sunrpc_tuning').with_content(/128/) }
-          it { is_expected.to contain_service('sunrpc_tuning') }
-          it { is_expected.to contain_sysctl('sunrpc.tcp_slot_table_entries') }
-          it { is_expected.to contain_sysctl('sunrpc.udp_slot_table_entries') }
-          it { is_expected.to contain_concat__fragment('nfs_init_server').without_content(%r(RPCSVCGSSDARGS=)) }
-        end
-
-        context "as a server with custom args" do
-          let(:hieradata) { 'rpcgssdargs' }
-          let(:params) {{
-            :is_server   => true,
-            :tcpwrappers => true,
-            :stunnel     => true,
-            :kerberos    => true,
-            :firewall    => true
-          }}
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_class('nfs') }
-          it { is_expected.to contain_class('nfs::server') }
-          it { is_expected.to contain_concat__fragment('nfs_init_server').with_content(%r(\nRPCSVCGSSDARGS="-n -vvvvv -rrrrr -iiiiii")) }
-          it { is_expected.to contain_class('tcpwrappers') }
-          it { is_expected.to contain_tcpwrappers__allow('nfs') }
-          it { is_expected.to contain_tcpwrappers__allow('mountd') }
-          it { is_expected.to contain_tcpwrappers__allow('statd') }
-          it { is_expected.to contain_tcpwrappers__allow('rquotad') }
-          it { is_expected.to contain_tcpwrappers__allow('lockd') }
-          it { is_expected.to contain_tcpwrappers__allow('rpcbind') }
-          it { is_expected.to contain_class('krb5') }
-          it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=no/) }
-        end
-
-        context 'with secure_nfs => true' do
-          let(:hieradata) { 'server_secure' }
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=yes/) }
-
-          if facts[:osfamily] == 'RedHat'
-            if facts[:operatingsystemmajrelease] >= '7'
-              it { is_expected.to contain_service('rpc-gssd').with(:ensure => 'running') }
-              if facts[:os][:release][:full] >= '7.1.0'
-                it { is_expected.to contain_service('gssproxy').with(:ensure => 'running') }
-              else
-                it { is_expected.to contain_service('rpc-svcgssd').with(:ensure => 'running') }
-              end
-            else
-              it { is_expected.to contain_service('rpcgssd').with(:ensure => 'running') }
-              it { is_expected.to contain_service('rpcsvcgssd').with(:ensure => 'running') }
-            end
-          end
-        end
-
+      shared_examples_for "a fact set" do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('nfs') }
+        it { is_expected.to contain_package('nfs-utils').with({
+            :ensure  => 'latest'
+          })
+        }
+        it { is_expected.to contain_package('nfs4-acl-tools').with_ensure('latest') }
       end
+
+      if os =~ /(?:redhat|centos)-(\d+)/
+        it_behaves_like "a fact set"
+        it { is_expected.to contain_concat__fragment('nfs_init').with_content(%r(MOUNTD_PORT=20048)) }
+      end
+
+      context "as a server with default params" do
+        let(:params){{
+          :is_server => true
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('nfs') }
+        it { is_expected.to contain_class('nfs::client') }
+        it { is_expected.to contain_class('nfs::server') }
+        it { is_expected.to_not contain_class('tcpwrappers') }
+        it { is_expected.to_not contain_class('krb5') }
+        it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=no/) }
+        it { is_expected.to create_concat('/etc/sysconfig/nfs') }
+        it { is_expected.to create_exec('nfs_re-export').with({
+            :command     => '/usr/sbin/exportfs -ra',
+            :refreshonly => true,
+            :require     => 'Package[nfs-utils]'
+          })
+        }
+
+        if ['RedHat','CentOS'].include?(facts[:operatingsystem]) && facts[:operatingsystemmajrelease].to_s < '7'
+          it { is_expected.to contain_service('nfs').with({
+              :ensure  => 'running'
+            })
+          }
+        else
+          it { is_expected.to contain_service('nfs-server').with({
+              :ensure  => 'running'
+            })
+          }
+        end
+        it { is_expected.to create_file('/etc/init.d/sunrpc_tuning').with_content(/128/) }
+        it { is_expected.to contain_service('sunrpc_tuning') }
+        it { is_expected.to contain_sysctl('sunrpc.tcp_slot_table_entries') }
+        it { is_expected.to contain_sysctl('sunrpc.udp_slot_table_entries') }
+        it { is_expected.to contain_concat__fragment('nfs_init_server').without_content(%r(RPCSVCGSSDARGS=)) }
+      end
+
+      context "as a server with custom args" do
+        let(:hieradata) { 'rpcgssdargs' }
+        let(:params) {{
+          :is_server   => true,
+          :tcpwrappers => true,
+          :stunnel     => true,
+          :kerberos    => true,
+          :firewall    => true
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('nfs') }
+        it { is_expected.to contain_class('nfs::server') }
+        it { is_expected.to contain_concat__fragment('nfs_init_server').with_content(%r(\nRPCSVCGSSDARGS="-n -vvvvv -rrrrr -iiiiii")) }
+        it { is_expected.to contain_class('tcpwrappers') }
+        it { is_expected.to contain_tcpwrappers__allow('nfs') }
+        it { is_expected.to contain_tcpwrappers__allow('mountd') }
+        it { is_expected.to contain_tcpwrappers__allow('statd') }
+        it { is_expected.to contain_tcpwrappers__allow('rquotad') }
+        it { is_expected.to contain_tcpwrappers__allow('lockd') }
+        it { is_expected.to contain_tcpwrappers__allow('rpcbind') }
+        it { is_expected.to contain_class('krb5') }
+        it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=no/) }
+      end
+
+      context 'with secure_nfs => true' do
+        let(:hieradata) { 'server_secure' }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('nfs_init').with_content(/SECURE_NFS=yes/) }
+
+        if facts[:osfamily] == 'RedHat'
+          if facts[:operatingsystemmajrelease] >= '7'
+            it { is_expected.to contain_service('rpc-gssd').with(:ensure => 'running') }
+            if facts[:os][:release][:full] >= '7.1.0'
+              it { is_expected.to contain_service('gssproxy').with(:ensure => 'running') }
+            else
+              it { is_expected.to contain_service('rpc-svcgssd').with(:ensure => 'running') }
+            end
+          else
+            it { is_expected.to contain_service('rpcgssd').with(:ensure => 'running') }
+            it { is_expected.to contain_service('rpcsvcgssd').with(:ensure => 'running') }
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/classes/server/stunnel_spec.rb
+++ b/spec/classes/server/stunnel_spec.rb
@@ -1,15 +1,26 @@
 require 'spec_helper'
 
 describe 'nfs::server::stunnel' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:pre_condition) { 'class { "nfs": is_server => true }' }
       let(:facts) { facts }
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('nfs::server') }
-      it { is_expected.to create_stunnel__instance('nfs') }
       it { is_expected.to create_class('nfs::server::stunnel') }
+      if facts[:os][:release][:major] == '7'
+        it { is_expected.to create_stunnel__instance('nfs').with_systemd_wantedby([
+          'rpc-statd',
+          'nfs-mountd',
+          'nfs-rquotad',
+          'nfs-server',
+          'rpcbind.socket',
+          'nfs-idmapd',
+          'rpc-gssd',
+          'gssproxy',
+        ] ) }
+      end
     end
   end
 end

--- a/spec/classes/server/stunnel_spec.rb
+++ b/spec/classes/server/stunnel_spec.rb
@@ -11,14 +11,14 @@ describe 'nfs::server::stunnel' do
       it { is_expected.to create_class('nfs::server::stunnel') }
       if facts[:os][:release][:major] == '7'
         it { is_expected.to create_stunnel__instance('nfs').with_systemd_wantedby([
-          'rpc-statd',
-          'nfs-mountd',
-          'nfs-rquotad',
-          'nfs-server',
+          'rpc-statd.service',
+          'nfs-mountd.service',
+          'nfs-rquotad.service',
+          'nfs-server.service',
           'rpcbind.socket',
-          'nfs-idmapd',
-          'rpc-gssd',
-          'gssproxy',
+          'nfs-idmapd.service',
+          'rpc-gssd.service',
+          'gssproxy.service',
         ] ) }
       end
     end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -3,14 +3,8 @@ require 'spec_helper'
 # most of server class is tested in init_spec.rb.  Here we are focusing on the
 # content of the concat fragment
 describe 'nfs::server' do
-  before(:each) do
-    Puppet::Parser::Functions.newfunction('assert_private') do |f|
-      f.stubs(:call).returns(true)
-    end
-  end
-
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
       let(:facts) { facts }
 
       context "on #{os}" do


### PR DESCRIPTION
On systemd systems, the stunnel service is now a dependency of the NFS
servers and mounts managed by this module.

SIMP-4637 #close