### PR TITLE
(SIMP-5008) Added nfs::client::mount::ensure param

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@ fixtures:
     augeasproviders_core: https://github.com/simp/augeasproviders_core
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
+    augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
     autofs: https://github.com/simp/pupmod-simp-autofs
     concat:
       # master is beyond 4.1.1, but has breaking changes to
@@ -15,6 +16,7 @@ fixtures:
     krb5: https://github.com/simp/pupmod-simp-krb5
     pki: https://github.com/simp/pupmod-simp-pki
     simplib: https://github.com/simp/pupmod-simp-simplib
+    ssh: https://github.com/simp/pupmod-simp-ssh
     stdlib: https://github.com/simp/puppetlabs-stdlib
     stunnel: https://github.com/simp/pupmod-simp-stunnel
     svckill: https://github.com/simp/pupmod-simp-svckill

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-* Thu Jul 12 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.1.2-0
+* Sun Oct 21 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0-0
+- Added a nfs::client::mount::ensure parameter to allow users to set the state
+  of the mountpoints
+
+* Thu Jul 12 2018 Nick Miller <nick.miller@onyxpoint.com> - 6.2.0-0
 - Added OEL and Puppet 5 support
 - Change rpcbind service name on EL7 from `rpcbind.socket` to,
   `rpcbind.service`, but only on EL7.4+

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "6.1.2",
+  "version": "6.2.0",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/00_basic_test_spec.rb
+++ b/spec/acceptance/suites/default/00_basic_test_spec.rb
@@ -9,7 +9,8 @@ describe 'nfs basic' do
 
   let(:manifest) {
     <<-EOM
-      include '::nfs'
+      include 'nfs'
+      include 'ssh'
     EOM
   }
 
@@ -19,8 +20,11 @@ describe 'nfs basic' do
 simp_options::firewall : true
 simp_options::kerberos : false
 simp_options::stunnel : false
-simp_options::tcpwrappers : true
+simp_options::tcpwrappers : false
 simp_options::trusted_nets : ['ALL']
+
+ssh::server::conf::permitrootlogin : true
+ssh::server::conf::authorizedkeysfile : '.ssh/authorized_keys'
 
 # Set us up for a basic server for right now (no Kerberos)
 
@@ -55,7 +59,8 @@ nfs::is_server : #IS_SERVER#
   end
 
   server_manifest = <<-EOM
-    include '::nfs'
+    include 'nfs'
+    include 'ssh'
 
     file { '/srv/nfs_share':
       ensure => 'directory',
@@ -96,6 +101,8 @@ nfs::is_server : #IS_SERVER#
           server_fqdn = fact_on(server, 'fqdn')
 
           client_manifest = <<-EOM
+            include 'ssh'
+
             nfs::client::mount { '/mnt/#{server}':
               nfs_server        => '#{server_fqdn}',
               remote_path       => '/srv/nfs_share',
@@ -118,6 +125,8 @@ nfs::is_server : #IS_SERVER#
           server_fqdn = fact_on(server, 'fqdn')
 
           autofs_client_manifest = <<-EOM
+            include 'ssh'
+
             nfs::client::mount { '/mnt/#{server}':
               nfs_server        => '#{server_fqdn}',
               remote_path       => '/srv/nfs_share',


### PR DESCRIPTION
* Allow users to set the 'ensure' state of their client mountpoints in
  case they don't want them to be mounted by default.
* Fix the acceptance and spec tests

SIMP-5008 #close