### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,11 +6,7 @@ fixtures:
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl
     augeasproviders_ssh: https://github.com/simp/augeasproviders_ssh
     autofs: https://github.com/simp/pupmod-simp-autofs
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     krb5: https://github.com/simp/pupmod-simp-krb5

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Mar 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.1-0
+- Expanded the upper limit of the concat and stdlib Puppet module versions
+- Updated URLs in the README.md
+
 * Thu Nov 01 2018 Jeanne Greulich <jeanne,greulich@onyxpoint.com> - 6.2.0-0
 - Update static assets for puppet 5
 - Update to onyxpoint OEL boxes in acceptance tests

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ able to access any shares from that realm.
 
 ### Automatic mounting of home directories
 
-Please reference the [SIMP documentation](http://simp.readthedocs.io/en/master/user_guide/HOWTO/NFS.html#exporting-home-directories) for details on how to implement this feature.
+Please reference the [SIMP documentation](https://simp.readthedocs.io/en/stable/user_guide/HOWTO/NFS.html#exporting-home-directories) for details on how to implement this feature.
 
 ## Reference
 
@@ -262,7 +262,7 @@ and module dependencies.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ### Acceptance tests
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",
@@ -16,11 +16,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
+      "version_requirement": ">= 2.2.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Expanded the upper limit of the concat and stdlib Puppet module versions
- Updated URLs in the README.md

SIMP-6213 #comment pupmod-simp-nfs