### PR TITLE
(SIMP-7018) simp-nfs runs same tests multiple times in GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,13 +163,13 @@ pup5.5.10:
   <<: *pup_5_5_10
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default]'
 
 pup5.5.10-fips:
   <<: *pup_5_5_10
   <<: *acceptance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
 pup5.5.10-oel:
   <<: *pup_5_5_10
@@ -214,14 +214,14 @@ pup6:
   <<: *pup_6
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default]'
 
 pup6-fips:
   <<: *pup_6
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
 pup6-stunnel:
   <<: *pup_6


### PR DESCRIPTION
Explicitly set suite so each job is clearly defined and there
are no overlaps with implied suites.  Without this change,
the stunnel suite is unnecessarily executed multiple times
for the same configuration.

SIMP-7018 #close