### PR TITLE
(SIMP-7453) Fix NFS export code

### DIFF
--- a/spec/defines/server/export_spec.rb
+++ b/spec/defines/server/export_spec.rb
@@ -14,15 +14,20 @@ describe 'nfs::server::export' do
 
       context 'with default parameters' do
         let(:params) { base_params }
+
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('nfs::server') }
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(
-          <<~EOM
-            /foo/bar/baz 0.0.0.0/0(sync,security_label,sec=sys,anonuid=65534,anongid=65534)
-            /foo/bar/baz 127.0.0.1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
-          EOM
-        ) }
 
+        content = <<~EOM
+          /foo/bar/baz 0.0.0.0/0(sync,security_label,sec=sys,anonuid=65534,anongid=65534)
+          /foo/bar/baz 127.0.0.1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+        EOM
+
+        if os_facts[:ipv6_enabled]
+          content += "/foo/bar/baz ::1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)\n"
+        end
+
+        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
         it { is_expected.to contain_selboolean('nfsd_anon_write') }
       end
 
@@ -47,12 +52,17 @@ describe 'nfs::server::export' do
         }) }
 
         it { is_expected.to contain_class('nfs::server') }
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(
-          <<~EOM
-            /foo/bar/baz 0.0.0.0/0(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
-            /foo/bar/baz 127.0.0.1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
-         EOM
-        ) }
+
+        content = <<~EOM
+          /foo/bar/baz 0.0.0.0/0(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
+          /foo/bar/baz 127.0.0.1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
+        EOM
+
+        if os_facts[:ipv6_enabled]
+          content += "/foo/bar/baz ::1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)\n"
+        end
+
+        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
       end
 
       context 'with optional parameters set and mountpoint is a path' do
@@ -65,35 +75,50 @@ describe 'nfs::server::export' do
         }) }
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(
-          <<~EOM
-            # some comment
-            /foo/bar/baz 0.0.0.0/0(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534)
-            /foo/bar/baz 127.0.0.1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
-          EOM
-        ) }
+
+        content = <<~EOM
+          # some comment
+          /foo/bar/baz 0.0.0.0/0(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534)
+          /foo/bar/baz 127.0.0.1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+        EOM
+
+        if os_facts[:ipv6_enabled]
+          content += "/foo/bar/baz ::1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)\n"
+        end
+
+        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
       end
 
       context 'with mountpoint is a true' do
         let(:params) { base_params.merge({ :mountpoint => true }) }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(
-          <<~EOM
-            /foo/bar/baz 0.0.0.0/0(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534)
-            /foo/bar/baz 127.0.0.1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
-          EOM
-        ) }
+
+        content = <<~EOM
+          /foo/bar/baz 0.0.0.0/0(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534)
+          /foo/bar/baz 127.0.0.1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+        EOM
+
+        if os_facts[:ipv6_enabled]
+          content += "/foo/bar/baz ::1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)\n"
+        end
+
+        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
       end
 
       context 'with custom set' do
         let(:params) { base_params.merge({ :custom => 'some custom setting' }) }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(
-          <<~EOM
-            /foo/bar/baz 0.0.0.0/0(somecustomsetting)
-            /foo/bar/baz 127.0.0.1(somecustomsetting,insecure)
-          EOM
-        ) }
+
+        content = <<~EOM
+          /foo/bar/baz 0.0.0.0/0(somecustomsetting)
+          /foo/bar/baz 127.0.0.1(somecustomsetting,insecure)
+        EOM
+
+        if os_facts[:ipv6_enabled]
+          content += "/foo/bar/baz ::1(somecustomsetting,insecure)\n"
+        end
+
+        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
       end
 
       context "with selinux disabled and 'sys' in 'sec' parameter" do

--- a/templates/etc/export.erb
+++ b/templates/etc/export.erb
@@ -97,9 +97,10 @@ _output = Array.new
 # Put it all together
 _client = Array(@clients.dup).flatten
 _client.map! { |cl| (['ALL','all','ANY','any'].include? cl) ? '*' : cl }.flatten!
-_client.push("127.0.0.1")
+_client.push('127.0.0.1')
+_client.push('::1') if @facts['ipv6_enabled']
 _client.uniq.sort.each do |cl|
-  if (cl == '127.0.0.1') && !@insecure
+  if ['127.0.0.1', '::1'].include?(cl) && !@insecure
     # Sometimes stunnel will bind on a high port, so we need to account for
     # that.
     _output.push("#{@export_path} #{cl}#{_options.split(')').first + ',insecure)'}")


### PR DESCRIPTION
An issue was discovered while testing simp_nfs with EL8 where the
/etc/exports was not adding `::1` to entries on IPv6 systems and this
was causing connections over `stunnel` to occasionally fail.

This patch ensures that IPv6 and IPv4 entries are added if the system is
IPv6 enabled.

SIMP-7453 #comment Fix ::1 issue in /etc/exports