### PR TITLE
(SIMP-10049) nfs Add Puppet 7 acceptance test

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 ---
 fixtures:
   repositories:
-    augeas_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
+    augeas_core: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
     augeasproviders_core: https://github.com/simp/augeasproviders_core.git
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub.git
     augeasproviders_sysctl: https://github.com/simp/augeasproviders_sysctl.git
@@ -14,13 +12,9 @@ fixtures:
     haveged: https://github.com/simp/pupmod-simp-haveged.git
     iptables: https://github.com/simp/pupmod-simp-iptables.git
     krb5: https://github.com/simp/pupmod-simp-krb5.git
-    mount_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-mount_core.git
-      puppet_version: ">= 6.0.0"
+    mount_core: https://github.com/simp/pupmod-puppetlabs-mount_core.git
     pki: https://github.com/simp/pupmod-simp-pki.git
-    selinux_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
-      puppet_version: ">= 6.0.0"
+    selinux_core: https://github.com/simp/pupmod-puppetlabs-selinux_core.git
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     ssh: https://github.com/simp/pupmod-simp-ssh.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,7 +237,7 @@ variables:
     MATRIX_RUBY_VERSION: '2.5'
 
 .pup_7_x: &pup_7_x
-  image: 'ruby:2.7'
+  image: 'docker.io/simpproject/simp_beaker_el7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -452,3 +452,23 @@ pup6.x-fips-stunnel:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[stunnel,default]'
+
+pup7.x:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,default]'
+
+pup7.x-krb5:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'bundle exec rake beaker:suites[krb5,default]'
+
+pup7.x-stunnel:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  script:
+    - 'bundle exec rake beaker:suites[stunnel,default]'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,7 +237,7 @@ variables:
     MATRIX_RUBY_VERSION: '2.5'
 
 .pup_7_x: &pup_7_x
-image: 'ruby:2.7'
+  image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,7 +237,7 @@ variables:
     MATRIX_RUBY_VERSION: '2.5'
 
 .pup_7_x: &pup_7_x
-  image: 'docker.io/simpproject/simp_beaker_el7'
+image: 'ruby:2.7'
   variables:
     PUPPET_VERSION: '~> 7.0'
     BEAKER_PUPPET_COLLECTION: 'puppet7'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Tue Jul 06 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.0
+- Fixed
+  - Added _netdev to the default mount options
+  - Ensure that remote-fs.target is enabled
+
 * Wed Jun 16 2021 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.1.0
 - Removed support for Puppet 5
 - Ensured support for Puppet 7 in requirements and stdlib

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.3', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,16 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
-  gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.3'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.2', '< 6']
+
+  # Fix this when PDK allows json_pure 2.5.1+
+  if major_puppet_version < 7
+    gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false)
+  else
+    gem 'json_pure', ['>= 2.5.1', '< 3']
+  end
+
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
 

--- a/manifests/client/mount.pp
+++ b/manifests/client/mount.pp
@@ -258,9 +258,9 @@ define nfs::client::mount (
   #################################
 
   if ($nfs_version  == 4) {
-    $_nfs_base_options = "nfsvers=4,port=${_nfsd_port},${options},sec=${sec}"
+    $_nfs_base_options = "_netdev,nfsvers=4,port=${_nfsd_port},${options},sec=${sec}"
   } else {
-    $_nfs_base_options = "nfsvers=3,port=${_nfsd_port},${options}"
+    $_nfs_base_options = "_netdev,nfsvers=3,port=${_nfsd_port},${options}"
   }
 
   if $_stunnel {
@@ -331,6 +331,8 @@ define nfs::client::mount (
     }
 
   } else {
+    ensure_resource('service', 'remote-fs.target', { 'enable' => true })
+
     mount { $name:
       ensure   => $ensure,
       atboot   => $at_boot,

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -37,7 +37,7 @@ HOSTS:
       - nfs_server
       - nfs_server_and_client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       epel:
@@ -49,7 +49,7 @@ HOSTS:
     roles:
       - nfs_client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
     yum_repos:
       epel:

--- a/spec/classes/base/config_spec.rb
+++ b/spec/classes/base/config_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::base::config' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with default nfs parameters' do
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/base/service_spec.rb
+++ b/spec/classes/base/service_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::base::service' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'NFSv3' do
           context 'with nfs::nfsv3 false' do

--- a/spec/classes/client/config_spec.rb
+++ b/spec/classes/client/config_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::client::config' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with default nfs and nfs::client parameters' do
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/client/service_spec.rb
+++ b/spec/classes/client/service_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::client::service' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with default nfs and nfs::client parameters' do
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/client/tcpwrappers_spec.rb
+++ b/spec/classes/client/tcpwrappers_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::client::tcpwrappers' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'when tcpwrappers and nfsv3 enabled' do
           let(:params) {{

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::client' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with default nfs and nfs::client parameters' do
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -6,7 +6,7 @@ describe 'nfs' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) {
-          # to workaround service provider issues related to masking
+          # to workaround service provider issues related to masking haveged
           # when tests are run on GitLab runners which are docker containers
           os_facts.merge( { :haveged__rngd_enabled => false } )
         }

--- a/spec/classes/idmapd/server_spec.rb
+++ b/spec/classes/idmapd/server_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::idmapd::server' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with nfs::idmapd=true' do
           let(:params) {{

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,7 +4,7 @@ describe 'nfs' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) {
-        # to workaround service provider issues related to masking
+        # to workaround service provider issues related to masking haveged
         # when tests are run on GitLab runners which are docker containers
         os_facts.merge( { :haveged__rngd_enabled => false } )
       }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 describe 'nfs' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts){ os_facts }
+      let(:facts) {
+        # to workaround service provider issues related to masking
+        # when tests are run on GitLab runners which are docker containers
+        os_facts.merge( { :haveged__rngd_enabled => false } )
+      }
 
       shared_examples_for 'a NFS base installer' do
         it { is_expected.to compile.with_all_deps }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::install' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'default nfs and nfs::install parameters' do
           it { is_expected.to compile.with_all_deps }

--- a/spec/classes/server/config_spec.rb
+++ b/spec/classes/server/config_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::server::config' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with default nfs and nfs::server parameters' do
           let(:params) {{ :is_server => true }}

--- a/spec/classes/server/firewall/nfsv3and4_spec.rb
+++ b/spec/classes/server/firewall/nfsv3and4_spec.rb
@@ -5,7 +5,12 @@ describe 'nfs' do
   describe 'private nfs::server::firewall::nfs3andv4' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
+
         let(:params) { {
           # nfs class params
           :is_server    => true,

--- a/spec/classes/server/firewall/nfsv4_spec.rb
+++ b/spec/classes/server/firewall/nfsv4_spec.rb
@@ -5,7 +5,12 @@ describe 'nfs' do
   describe 'private nfs::server::firewall::nfsv4' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
+
         let(:params) { {
           # nfs class params
           :is_server    => true,

--- a/spec/classes/server/firewall_spec.rb
+++ b/spec/classes/server/firewall_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::server::firewall' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'when stunnel enabled' do
           context 'when nfsv3 enabled' do

--- a/spec/classes/server/service_spec.rb
+++ b/spec/classes/server/service_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::server::service' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         let(:params) {{ :is_server => true, }}
 

--- a/spec/classes/server/stunnel_spec.rb
+++ b/spec/classes/server/stunnel_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::server::stunnel' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         let(:params) {{
           :is_server    => true,

--- a/spec/classes/server/tcpwrappers_spec.rb
+++ b/spec/classes/server/tcpwrappers_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::server::tcpwrappers' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts){ os_facts }
+        let(:facts) {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'when tcpwrappers and nfsv3 enabled' do
           let(:params) {{

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -5,7 +5,11 @@ describe 'nfs' do
   describe 'private nfs::server' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { os_facts}
+        let(:facts) {
+          # to workaround service provider issues related to masking
+          # when tests are run on GitLab runners which are docker containers
+          os_facts.merge( { :haveged__rngd_enabled => false } )
+        }
 
         context 'with default nfs and nfs::server parameters' do
           let(:params) {{ :is_server => true }}

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -6,7 +6,7 @@ describe 'nfs' do
     on_supported_os.each do |os, os_facts|
       context "on #{os}" do
         let(:facts) {
-          # to workaround service provider issues related to masking
+          # to workaround service provider issues related to masking haveged
           # when tests are run on GitLab runners which are docker containers
           os_facts.merge( { :haveged__rngd_enabled => false } )
         }

--- a/spec/defines/client/mount/connection_spec.rb
+++ b/spec/defines/client/mount/connection_spec.rb
@@ -9,7 +9,12 @@ describe 'nfs::client::mount::connection' do
       end
 
       let(:pre_condition) { "include 'nfs'" }
-      let(:facts) { os_facts }
+      let(:facts) {
+        # to workaround service provider issues related to masking haveged
+        # when tests are run on GitLab runners which are docker containers
+        os_facts.merge( { :haveged__rngd_enabled => false } )
+      }
+
       let(:title) { '/mnt/apps' }
 
       context 'when stunnel=true and nfs_version=4' do

--- a/spec/defines/client/mount_spec.rb
+++ b/spec/defines/client/mount_spec.rb
@@ -9,7 +9,11 @@ describe 'nfs::client::mount' do
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      let(:facts) {
+        # to workaround service provider issues related to masking haveged
+        # when tests are run on GitLab runners which are docker containers
+        os_facts.merge( { :haveged__rngd_enabled => false } )
+      }
 
       let(:title) { '/net/apps' }
       let(:nfs_server) { '1.2.3.4'}

--- a/spec/defines/client/mount_spec.rb
+++ b/spec/defines/client/mount_spec.rb
@@ -31,6 +31,7 @@ describe 'nfs::client::mount' do
 
         context 'with defaults for nfs and nfs::client' do
           include_examples 'a base client mount define'
+          it { is_expected.not_to contain_service('remote-fs.target') }
           it 'should use nfs & nfs::client defaults for unspecified connection params' do
             is_expected.to create_nfs__client__mount__connection(title).with( {
               :nfs_server             => params[:nfs_server],
@@ -51,7 +52,7 @@ describe 'nfs::client::mount' do
               :mount_point => '/-',
               :mappings    => {
                 'key'      => title,
-                'options'  => '-nfsvers=4,port=2049,soft,sec=sys',
+                'options'  => '-_netdev,nfsvers=4,port=2049,soft,sec=sys',
                 'location' => "#{params[:nfs_server]}:#{params[:remote_path]}"
               }
           } ) }
@@ -96,7 +97,7 @@ describe 'nfs::client::mount' do
                 :mount_point => '/-',
                 :mappings    => {
                   'key'      => title,
-                  'options'  => '-nfsvers=3,port=2049,soft',
+                  'options'  => '-_netdev,nfsvers=3,port=2049,soft',
                   'location' => "#{params[:nfs_server]}:#{params[:remote_path]}"
                 }
             } ) }
@@ -131,7 +132,7 @@ describe 'nfs::client::mount' do
                 :mount_point => '/-',
                 :mappings    => {
                   'key'      => title,
-                  'options'  => '-nfsvers=4,port=2050,soft,sec=sys,proto=tcp',
+                  'options'  => '-_netdev,nfsvers=4,port=2050,soft,sec=sys,proto=tcp',
                   'location' => "127.0.0.1:#{params[:remote_path]}"
                 }
             } ) }
@@ -157,7 +158,7 @@ describe 'nfs::client::mount' do
                 :mount_point => '/-',
                 :mappings    => {
                   'key'      => title,
-                  'options'  => '-nfsvers=4,port=2049,soft,sec=sys',
+                  'options'  => '-_netdev,nfsvers=4,port=2049,soft,sec=sys',
                   'location' => "#{params[:nfs_server]}:#{params[:remote_path]}"
                 }
             } ) }
@@ -182,7 +183,7 @@ describe 'nfs::client::mount' do
                 :mount_point => title,
                 :mappings    => [ {
                   'key'      => params[:autofs_indirect_map_key],
-                  'options'  => '-nfsvers=3,port=2049,soft',
+                  'options'  => '-_netdev,nfsvers=3,port=2049,soft',
                   'location' => "#{params[:nfs_server]}:#{params[:remote_path]}"
                 } ]
             } ) }
@@ -201,7 +202,7 @@ describe 'nfs::client::mount' do
                 :mount_point => title,
                 :mappings    => [ {
                   'key'      => params[:autofs_indirect_map_key],
-                  'options'  => '-nfsvers=4,port=2049,soft,sec=sys,proto=tcp',
+                  'options'  => '-_netdev,nfsvers=4,port=2049,soft,sec=sys,proto=tcp',
                   'location' => "127.0.0.1:#{params[:remote_path]}"
                 } ]
             } ) }
@@ -220,7 +221,7 @@ describe 'nfs::client::mount' do
                 :mount_point => title,
                 :mappings    => [ {
                   'key'      => params[:autofs_indirect_map_key],
-                  'options'  => '-nfsvers=4,port=2049,soft,sec=sys',
+                  'options'  => '-_netdev,nfsvers=4,port=2049,soft,sec=sys',
                   'location' => "#{params[:nfs_server]}:#{params[:remote_path]}"
                 } ]
             } ) }
@@ -239,7 +240,7 @@ describe 'nfs::client::mount' do
                 :mount_point => title,
                 :mappings    => [ {
                   'key'      => params[:autofs_indirect_map_key],
-                  'options'  => '-nfsvers=4,port=2049,soft,sec=sys',
+                  'options'  => '-_netdev,nfsvers=4,port=2049,soft,sec=sys',
                   'location' => "#{params[:nfs_server]}:#{params[:remote_path]}/&"
                 } ]
             } ) }
@@ -260,12 +261,13 @@ describe 'nfs::client::mount' do
 
           include_examples 'a base client mount define'
           it { is_expected.to create_nfs__client__mount__connection(title).with_nfs_version(3) }
+          it { is_expected.to contain_service('remote-fs.target').with_enable(true) }
           it { is_expected.to contain_mount(title).with( {
             :ensure   => 'mounted',
             :atboot   => true,
             :device   => "#{params[:nfs_server]}:#{params[:remote_path]}",
             :fstype   => 'nfs',
-            :options  => 'nfsvers=3,port=2049,soft',
+            :options  => '_netdev,nfsvers=3,port=2049,soft',
             :remounts => false
           } ) }
 
@@ -278,12 +280,13 @@ describe 'nfs::client::mount' do
 
           include_examples 'a base client mount define'
           it { is_expected.to create_nfs__client__mount__connection(title).with_nfs_version(4) }
+          it { is_expected.to contain_service('remote-fs.target').with_enable(true) }
           it { is_expected.to contain_mount(title).with( {
             :ensure   => 'mounted',
             :atboot   => true,
             :device   => "127.0.0.1:#{params[:remote_path]}",
             :fstype   => 'nfs',
-            :options  => 'nfsvers=4,port=2049,soft,sec=sys,proto=tcp',
+            :options  => '_netdev,nfsvers=4,port=2049,soft,sec=sys,proto=tcp',
             :remounts => false
           } ) }
 
@@ -296,12 +299,13 @@ describe 'nfs::client::mount' do
 
           include_examples 'a base client mount define'
           it { is_expected.to create_nfs__client__mount__connection(title).with_nfs_version(4) }
+          it { is_expected.to contain_service('remote-fs.target').with_enable(true) }
           it { is_expected.to contain_mount(title).with( {
             :ensure   => 'mounted',
             :atboot   => true,
             :device   => "#{params[:nfs_server]}:#{params[:remote_path]}",
             :fstype   => 'nfs',
-            :options  => 'nfsvers=4,port=2049,soft,sec=sys',
+            :options  => '_netdev,nfsvers=4,port=2049,soft,sec=sys',
             :remounts => false
           } ) }
 
@@ -320,12 +324,13 @@ describe 'nfs::client::mount' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_nfs__client__mount__connection(title).with_nfs_version(4) }
+          it { is_expected.to contain_service('remote-fs.target').with_enable(true) }
           it { is_expected.to contain_mount(title).with( {
             :ensure   => 'present',
             :atboot   => false,
             :device   => "#{params[:nfs_server]}:#{params[:remote_path]}",
             :fstype   => 'nfs',
-            :options  => 'nfsvers=4,port=2049,soft,sec=sys',
+            :options  => '_netdev,nfsvers=4,port=2049,soft,sec=sys',
             :remounts => false
           } ) }
         end
@@ -349,13 +354,14 @@ describe 'nfs::client::mount' do
 
           include_examples 'a base client mount define'
           it { is_expected.to create_nfs__client__mount__connection(title).with_nfs_version(4) }
+          it { is_expected.to contain_service('remote-fs.target').with_enable(true) }
           it 'should not use localhost for mount' do
             is_expected.to contain_mount(title).with( {
               :ensure   => 'mounted',
               :atboot   => true,
               :device   => "#{params[:nfs_server]}:#{params[:remote_path]}",
               :fstype   => 'nfs',
-              :options  => 'nfsvers=4,port=2049,soft,sec=sys',
+              :options  => '_netdev,nfsvers=4,port=2049,soft,sec=sys',
               :remounts => false
             } )
           end
@@ -364,13 +370,14 @@ describe 'nfs::client::mount' do
         context 'autodetect_remote=true and simplib::host_is_me($host)=true' do
           let(:params) { base_params.merge( { :autodetect_remote => true } ) }
 
+          it { is_expected.to contain_service('remote-fs.target').with_enable(true) }
           it 'should use localhost for mount' do
             is_expected.to contain_mount(title).with( {
               :ensure   => 'mounted',
               :atboot   => true,
               :device   => "127.0.0.1:#{params[:remote_path]}",
               :fstype   => 'nfs',
-              :options  => 'nfsvers=4,port=2049,soft,sec=sys',
+              :options  => '_netdev,nfsvers=4,port=2049,soft,sec=sys',
               :remounts => false
             } )
           end

--- a/spec/defines/client/stunnel_spec.rb
+++ b/spec/defines/client/stunnel_spec.rb
@@ -8,7 +8,12 @@ describe 'nfs::client::stunnel' do
         Puppet::Parser::Functions.newfunction(:assert_private, :type => :rvalue) { |args| }
       end
 
-      let(:facts) { os_facts }
+      let(:facts) {
+        # to workaround service provider issues related to masking haveged
+        # when tests are run on GitLab runners which are docker containers
+        os_facts.merge( { :haveged__rngd_enabled => false } )
+      }
+
       let(:title) { '1.2.3.4:2049' }
       let(:params) {{
         :nfs_server             => '1.2.3.4',

--- a/spec/defines/server/export_spec.rb
+++ b/spec/defines/server/export_spec.rb
@@ -5,7 +5,15 @@ describe 'nfs::server::export' do
     context "on #{os}" do
       let(:pre_condition) { 'class { "nfs": is_server => true }' }
 
-      let(:facts) { os_facts }
+      let(:facts) {
+        os_facts.merge( {
+          # to workaround service provider issues related to masking haveged
+          # when tests are run on GitLab runners which are docker containers
+          :haveged__rngd_enabled => false,
+          :ipv6_enabled          => true
+        } )
+      }
+
       let(:title) { 'nfs_test' }
       base_params = {
         :export_path => '/foo/bar/baz',
@@ -18,16 +26,15 @@ describe 'nfs::server::export' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('nfs::server') }
 
-        content = <<~EOM
-          /foo/bar/baz 0.0.0.0/0(sync,security_label,sec=sys,anonuid=65534,anongid=65534)
-          /foo/bar/baz 127.0.0.1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
-        EOM
+        it {
+          content = <<~EOM
+            /foo/bar/baz 0.0.0.0/0(sync,security_label,sec=sys,anonuid=65534,anongid=65534)
+            /foo/bar/baz 127.0.0.1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+            /foo/bar/baz ::1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+          EOM
 
-        if os_facts[:ipv6_enabled]
-          content += "/foo/bar/baz ::1(sync,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)\n"
-        end
-
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
+          is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content)
+        }
         it { is_expected.to contain_selboolean('nfsd_anon_write') }
       end
 
@@ -53,16 +60,15 @@ describe 'nfs::server::export' do
 
         it { is_expected.to contain_class('nfs::server') }
 
-        content = <<~EOM
-          /foo/bar/baz 0.0.0.0/0(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
-          /foo/bar/baz 127.0.0.1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
+        it {
+          content = <<~EOM
+            /foo/bar/baz 0.0.0.0/0(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
+            /foo/bar/baz 127.0.0.1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
+            /foo/bar/baz ::1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)
         EOM
 
-        if os_facts[:ipv6_enabled]
-          content += "/foo/bar/baz ::1(insecure,rw,async,no_wdelay,nohide,crossmnt,subtree_check,insecure_locks,nordirplus,pnfs,sec=sys:krb5p,no_root_squash,all_squash,anonuid=65520,anongid=65530)\n"
-        end
-
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
+          is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content)
+        }
       end
 
       context 'with optional parameters set and mountpoint is a path' do
@@ -76,54 +82,58 @@ describe 'nfs::server::export' do
 
         it { is_expected.to compile.with_all_deps }
 
-        content = <<~EOM
-          # some comment
-          /foo/bar/baz 0.0.0.0/0(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534)
-          /foo/bar/baz 127.0.0.1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
-        EOM
+        it {
+          content = <<~EOM
+            # some comment
+            /foo/bar/baz 0.0.0.0/0(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534)
+            /foo/bar/baz 127.0.0.1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+            /foo/bar/baz ::1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+          EOM
 
-        if os_facts[:ipv6_enabled]
-          content += "/foo/bar/baz ::1(sync,mp=/mount/point/path,fsid=test_vsid,refer=/path@test_refer1:/path@test_refer2,replicas=/path@test_replica1:/path@test_replica2,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)\n"
-        end
-
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
+          is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content)
+        }
       end
 
       context 'with mountpoint is a true' do
         let(:params) { base_params.merge({ :mountpoint => true }) }
         it { is_expected.to compile.with_all_deps }
 
-        content = <<~EOM
-          /foo/bar/baz 0.0.0.0/0(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534)
-          /foo/bar/baz 127.0.0.1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+        it {
+          content = <<~EOM
+            /foo/bar/baz 0.0.0.0/0(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534)
+            /foo/bar/baz 127.0.0.1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
+            /foo/bar/baz ::1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)
         EOM
 
-        if os_facts[:ipv6_enabled]
-          content += "/foo/bar/baz ::1(sync,mp,security_label,sec=sys,anonuid=65534,anongid=65534,insecure)\n"
-        end
-
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
+          is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content)
+        }
       end
 
       context 'with custom set' do
         let(:params) { base_params.merge({ :custom => 'some custom setting' }) }
         it { is_expected.to compile.with_all_deps }
 
-        content = <<~EOM
-          /foo/bar/baz 0.0.0.0/0(somecustomsetting)
-          /foo/bar/baz 127.0.0.1(somecustomsetting,insecure)
-        EOM
+        it {
+          content = <<~EOM
+            /foo/bar/baz 0.0.0.0/0(somecustomsetting)
+            /foo/bar/baz 127.0.0.1(somecustomsetting,insecure)
+            /foo/bar/baz ::1(somecustomsetting,insecure)
+          EOM
 
-        if os_facts[:ipv6_enabled]
-          content += "/foo/bar/baz ::1(somecustomsetting,insecure)\n"
-        end
-
-        it { is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content) }
+          is_expected.to create_concat__fragment("nfs_#{title}_export").with_content(content)
+        }
       end
 
       context "with selinux disabled and 'sys' in 'sec' parameter" do
         let(:params) { base_params }
-        let(:facts) { os_facts.merge({ :selinux => false })}
+        let(:facts) {
+          os_facts.merge( {
+            # to workaround service provider issues related to masking haveged
+            # when tests are run on GitLab runners which are docker containers
+            :haveged__rngd_enabled => false,
+            :selinux               => false
+          } )
+        }
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to_not contain_selboolean('nfsd_anon_write') }
       end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -25,6 +25,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Add a Puppet 7 acceptance test
* Remove check for Puppet >=6 in .fixtures.yml
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-nfs acceptance tests configured
SIMP-10049 #close

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666