### PR TITLE
Update deps to use puppet/systemd

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -21,9 +21,7 @@ fixtures:
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git
-    systemd:
-      repo: https://github.com/simp/puppet-systemd.git
-      branch: simp-master
+    systemd: https://github.com/simp/puppet-systemd.git
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -21,7 +21,9 @@ fixtures:
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
     stunnel: https://github.com/simp/pupmod-simp-stunnel.git
     svckill: https://github.com/simp/pupmod-simp-svckill.git
-    systemd: https://github.com/simp/puppet-systemd.git
+    systemd:
+      repo: https://github.com/simp/puppet-systemd.git
+      branch: simp-master
     tcpwrappers: https://github.com/simp/pupmod-simp-tcpwrappers.git
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,12 @@
 .idea/
 dist
 /pkg
-/spec/fixtures
+# Read everything in fixtures
+/spec/fixtures/*
+# Un-ignore hieradata
+!/spec/fixtures/hieradata/*
+# Except this one, which is auto-generated
+/spec/fixtures/hieradata/hiera.yaml
 /spec/rp_env
 /.rspec_system
 /.vagrant

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -343,6 +343,7 @@ pup6.pe-fips:
   <<: *acceptance_base
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+  timeout: 2h
 
 pup6.pe-oel:
   <<: *pup_6_pe
@@ -356,6 +357,7 @@ pup6.pe-oel-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
+  timeout: 2h
 
 pup6.pe-krb5:
   <<: *pup_6_pe
@@ -369,6 +371,7 @@ pup6.pe-fips-krb5:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[krb5,default]'
+  timeout: 2h
 
 pup6.pe-oel-krb5:
   <<: *pup_6_pe
@@ -383,6 +386,7 @@ pup6.pe-oel-fips-krb5:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[krb5,oel]'
+  timeout: 2h
 
 pup6.pe-stunnel:
   <<: *pup_6_pe
@@ -396,6 +400,7 @@ pup6.pe-fips-stunnel:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[stunnel,default]'
+  timeout: 2h
 
 pup6.pe-oel-stunnel:
   <<: *pup_6_pe
@@ -410,6 +415,7 @@ pup6.pe-oel-fips-stunnel:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[stunnel,oel]'
+  timeout: 2h
 
 pup6.x:
   <<: *pup_6_x
@@ -424,6 +430,7 @@ pup6.x-fips:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+  timeout: 2h
 
 pup6.x-krb5:
   <<: *pup_6_x
@@ -438,6 +445,7 @@ pup6.x-fips-krb5:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[krb5,default]'
+  timeout: 2h
 
 pup6.x-stunnel:
   <<: *pup_6_x
@@ -452,6 +460,7 @@ pup6.x-fips-stunnel:
   <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[stunnel,default]'
+  timeout: 2h
 
 pup7.x:
   <<: *pup_7_x

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Jun 03 2022 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.2.0
+- Update from camptocamp/systemd to puppet/systemd
+
 * Tue Jul 06 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.1.0
 - Fixed
   - Added _netdev to the default mount options

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-nfs",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "author": "SIMP Team",
   "summary": "manages NFS server and client, also PKI and stunnelling",
   "license": "Apache-2.0",
@@ -15,8 +15,8 @@
   ],
   "dependencies": [
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.8.0 < 3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.0.0 < 4.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.10.0 < 4.0.0"
     },
     {
       "name": "herculesteam/augeasproviders_sysctl",

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -40,7 +40,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -40,7 +40,6 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  vagrant_memsize: 512
   ssh:
     keepalive: true
     keepalive_interval: 10


### PR DESCRIPTION
This patch updates from camptocamp/systemd 2.x to puppet/systemd 3.x

This bump is driven by simp/simp-core#829